### PR TITLE
Remove data_provider decorator

### DIFF
--- a/higra/__init__.py
+++ b/higra/__init__.py
@@ -9,9 +9,8 @@
 ############################################################################
 
 # pre-declaration of globals
-globals()["__data_providers"] = {}
 globals()["__higra_global_cache"] = None
-globals()["__provider_caching"] = True
+globals()["__auto_caching"] = True
 
 # extension module
 from .higram import *

--- a/higra/algo/tree_energy_optimization.py
+++ b/higra/algo/tree_energy_optimization.py
@@ -152,12 +152,11 @@ def attribute_piecewise_constant_Mumford_Shah_energy(tree, vertex_weights, gamma
     return variance * area + gamma * perimeter
 
 
-@hg.argument_helper(("graph", "vertex_area"), ("graph", "vertex_perimeter"), ("graph", "edge_length"))
 def binary_partition_tree_MumfordShah_energy(graph,
                                              vertex_values,
-                                             vertex_area,
-                                             vertex_perimeter,
-                                             edge_length,
+                                             vertex_area=None,
+                                             vertex_perimeter=None,
+                                             edge_length=None,
                                              squared_vertex_values=None):
     """
     Binary partition tree according to the Mumford-Shah energy with a constant piecewise model.
@@ -184,6 +183,15 @@ def binary_partition_tree_MumfordShah_energy(graph,
         vertex contains a single value.
     :return: a tree (Concept :class:`~higra.CptHierarchy`) and its node altitudes
     """
+    if vertex_area is None:
+        vertex_area = hg.attribute_vertex_area(graph)
+
+    if edge_length is None:
+        edge_length = hg.attribute_edge_length(graph)
+
+    if vertex_perimeter is None:
+        vertex_perimeter = hg.attribute_vertex_perimeter(graph, edge_length)
+
     vertex_values = hg.linearize_vertex_weights(vertex_values, graph)
     vertex_area = hg.linearize_vertex_weights(vertex_area, graph)
     vertex_perimeter = hg.linearize_vertex_weights(vertex_perimeter, graph)

--- a/higra/hierarchy/watershed_hierarchy.py
+++ b/higra/hierarchy/watershed_hierarchy.py
@@ -12,8 +12,7 @@ import higra as hg
 import numpy as np
 
 
-@hg.argument_helper("vertex_area")
-def watershed_hierarchy_by_area(graph, edge_weights, vertex_area):
+def watershed_hierarchy_by_area(graph, edge_weights, vertex_area=None):
     """
     Watershed hierarchy by area.
 
@@ -34,6 +33,9 @@ def watershed_hierarchy_by_area(graph, edge_weights, vertex_area):
     :param vertex_area: area of the input graph vertices (provided by :func:`~higra.attribute_vertex_area`)
     :return: a tree (Concept :class:`~higra.CptHierarchy`) and its node altitudes
     """
+    if vertex_area is None:
+        vertex_area = hg.attribute_vertex_area(graph)
+
     vertex_area = hg.linearize_vertex_weights(vertex_area, graph)
 
     vertex_area = hg.cast_to_dtype(vertex_area, np.float64)
@@ -46,8 +48,7 @@ def watershed_hierarchy_by_area(graph, edge_weights, vertex_area):
     return tree, altitudes
 
 
-@hg.argument_helper("vertex_area")
-def watershed_hierarchy_by_volume(graph, edge_weights, vertex_area):
+def watershed_hierarchy_by_volume(graph, edge_weights, vertex_area=None):
     """
     Watershed hierarchy by volume.
 
@@ -68,6 +69,9 @@ def watershed_hierarchy_by_volume(graph, edge_weights, vertex_area):
     :param vertex_area: area of the input graph vertices (provided by :func:`~higra.attribute_vertex_area`)
     :return: a tree (Concept :class:`~higra.CptHierarchy`) and its node altitudes
     """
+    if vertex_area is None:
+        vertex_area = hg.attribute_vertex_area(graph)
+
     vertex_area = hg.linearize_vertex_weights(vertex_area, graph)
 
     vertex_area = hg.cast_to_dtype(vertex_area, np.float64)

--- a/higra/structure/lca_fast.py
+++ b/higra/structure/lca_fast.py
@@ -11,13 +11,10 @@
 import higra as hg
 
 
-@hg.data_provider("LCAFast")
 @hg.auto_cache
 def make_lca_fast(tree):
     """
     Create an object of type :class:`~higra.LCAFast` for the given tree
-
-    **Provider name**: "LCAFast"
 
     :param tree: input tree
     :return: a LCAFast object

--- a/test/python/test_data_cache.py
+++ b/test/python/test_data_cache.py
@@ -29,42 +29,29 @@ class MyException(Exception):
         super().__init__(message)
 
 
-crash_provider1 = False
+crash_fun1 = False
 
 
 @hg.auto_cache
-def provider1(obj, a=None):
-    """
-    Provider 1
-
-    :param obj:
-    :param a:
-    :return:
-    """
-    global crash_provider1
-    if crash_provider1:
+def fun1(obj, a=None):
+    global crash_fun1
+    if crash_fun1:
         raise Exception("Should not have been called")
     return 1
 
 
-crash_provider2 = False
+crash_fun2 = False
 
 
 @hg.auto_cache
-def provider2(obj, a=None):
-    global crash_provider2
-    if crash_provider2:
+def fun2(obj, a=None):
+    global crash_fun2
+    if crash_fun2:
         raise Exception("Should not have been called")
     return 1
 
 
-@hg.data_provider("attr1")
-def attribute1(obj):
-    return 1
-
-
-@hg.argument_helper("attr1")
-def accept_everything(dummy, attr1):
+def accept_everything(dummy, attr1=1):
     return attr1
 
 
@@ -78,9 +65,8 @@ def accept_RegularGraph2d(graph, shape):
 crash_cached_attr = False
 
 
-@hg.argument_helper("attr1")
 @hg.auto_cache
-def cached_attr(o, attr1):
+def cached_attr(o, attr1=1):
     global crash_cached_attr
     if crash_cached_attr:
         raise Exception("Should not have been called")
@@ -101,123 +87,123 @@ def default_attr(o, v=1):
 class TestDataCache(unittest.TestCase):
 
     def test_auto_cache_and_force_recompute(self):
-        global crash_provider1
+        global crash_fun1
         obj1 = Dummy(1)
-        crash_provider1 = False
-        self.assertTrue(provider1(obj1, 1) == 1)
-        crash_provider1 = True
-        self.assertTrue(provider1(obj1, 1) == 1)
-        self.assertRaises(Exception, provider1, obj1, 2)
-        self.assertRaises(Exception, provider1, obj1, force_recompute=True)
+        crash_fun1 = False
+        self.assertTrue(fun1(obj1, 1) == 1)
+        crash_fun1 = True
+        self.assertTrue(fun1(obj1, 1) == 1)
+        self.assertRaises(Exception, fun1, obj1, 2)
+        self.assertRaises(Exception, fun1, obj1, force_recompute=True)
         hg.clear_all_attributes()
 
     def test_auto_cache_global_setting(self):
-        global crash_provider1
+        global crash_fun1
         obj1 = Dummy(1)
-        crash_provider1 = False
+        crash_fun1 = False
         hg.set_auto_cache_state(False)
-        self.assertTrue(provider1(obj1, 1) == 1)
-        crash_provider1 = True
-        self.assertRaises(Exception, provider1, obj1, 1)
+        self.assertTrue(fun1(obj1, 1) == 1)
+        crash_fun1 = True
+        self.assertRaises(Exception, fun1, obj1, 1)
         hg.set_auto_cache_state(True)
-        crash_provider1 = False
-        self.assertTrue(provider1(obj1, 2) == 1)
-        crash_provider1 = True
-        self.assertTrue(provider1(obj1, 2) == 1)
+        crash_fun1 = False
+        self.assertTrue(fun1(obj1, 2) == 1)
+        crash_fun1 = True
+        self.assertTrue(fun1(obj1, 2) == 1)
         hg.set_auto_cache_state(False)
-        self.assertRaises(Exception, provider1, obj1, 1)
+        self.assertRaises(Exception, fun1, obj1, 1)
         hg.set_auto_cache_state(True)
         hg.clear_all_attributes()
 
     def test_auto_cache_clearing(self):
-        global crash_provider1
-        global crash_provider2
+        global crash_fun1
+        global crash_fun2
         obj1 = Dummy(1)
         obj2 = Dummy(2)
 
-        crash_provider1 = False
-        crash_provider2 = False
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertTrue(provider1(obj2) == 1)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
-        hg.clear_auto_cache(function_name="provider1")
-        crash_provider1 = True
-        crash_provider2 = True
-        self.assertRaises(Exception, provider1, obj1)
-        self.assertRaises(Exception, provider1, obj2)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
+        crash_fun1 = False
+        crash_fun2 = False
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertTrue(fun1(obj2) == 1)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
+        hg.clear_auto_cache(function=fun1)
+        crash_fun1 = True
+        crash_fun2 = True
+        self.assertRaises(Exception, fun1, obj1)
+        self.assertRaises(Exception, fun1, obj2)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
 
-        crash_provider1 = False
-        crash_provider2 = False
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertTrue(provider1(obj2) == 1)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
+        crash_fun1 = False
+        crash_fun2 = False
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertTrue(fun1(obj2) == 1)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
         hg.clear_auto_cache(reference_object=obj2)
-        crash_provider1 = True
-        crash_provider2 = True
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertRaises(Exception, provider1, obj2)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertRaises(Exception, provider2, obj2)
+        crash_fun1 = True
+        crash_fun2 = True
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertRaises(Exception, fun1, obj2)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertRaises(Exception, fun2, obj2)
 
-        crash_provider1 = False
-        crash_provider2 = False
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertTrue(provider1(obj2) == 1)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
-        hg.clear_auto_cache(function_name="provider1", reference_object=obj2)
-        crash_provider1 = True
-        crash_provider2 = True
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertRaises(Exception, provider1, obj2)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
+        crash_fun1 = False
+        crash_fun2 = False
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertTrue(fun1(obj2) == 1)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
+        hg.clear_auto_cache(function="fun1", reference_object=obj2)
+        crash_fun1 = True
+        crash_fun2 = True
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertRaises(Exception, fun1, obj2)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
 
-        crash_provider1 = False
-        crash_provider2 = False
-        self.assertTrue(provider1(obj1) == 1)
-        self.assertTrue(provider1(obj2) == 1)
-        self.assertTrue(provider2(obj1) == 1)
-        self.assertTrue(provider2(obj2) == 1)
+        crash_fun1 = False
+        crash_fun2 = False
+        self.assertTrue(fun1(obj1) == 1)
+        self.assertTrue(fun1(obj2) == 1)
+        self.assertTrue(fun2(obj1) == 1)
+        self.assertTrue(fun2(obj2) == 1)
         hg.clear_auto_cache()
-        crash_provider1 = True
-        crash_provider2 = True
-        self.assertRaises(Exception, provider1, obj1)
-        self.assertRaises(Exception, provider1, obj2)
-        self.assertRaises(Exception, provider2, obj1)
-        self.assertRaises(Exception, provider2, obj2)
+        crash_fun1 = True
+        crash_fun2 = True
+        self.assertRaises(Exception, fun1, obj1)
+        self.assertRaises(Exception, fun1, obj2)
+        self.assertRaises(Exception, fun2, obj1)
+        self.assertRaises(Exception, fun2, obj2)
 
     def test_auto_cache_no_cache_implies_force_recompute(self):
-        global crash_provider1
+        global crash_fun1
         obj1 = Dummy(1)
-        crash_provider1 = False
-        self.assertTrue(provider1(obj1, 3) == 1)
-        crash_provider1 = True
-        self.assertTrue(provider1(obj1, 3) == 1)
-        self.assertRaises(Exception, provider1, obj1, 3, no_cache=True)
+        crash_fun1 = False
+        self.assertTrue(fun1(obj1, 3) == 1)
+        crash_fun1 = True
+        self.assertTrue(fun1(obj1, 3) == 1)
+        self.assertRaises(Exception, fun1, obj1, 3, no_cache=True)
         hg.clear_all_attributes()
 
     def test_auto_cache_no_cache_doesnt_store_result(self):
-        global crash_provider1
+        global crash_fun1
         obj1 = Dummy(1)
-        crash_provider1 = False
-        self.assertTrue(provider1(obj1, 2, no_cache=True) == 1)
-        crash_provider1 = True
-        self.assertRaises(Exception, provider1, obj1, 2)
+        crash_fun1 = False
+        self.assertTrue(fun1(obj1, 2, no_cache=True) == 1)
+        crash_fun1 = True
+        self.assertRaises(Exception, fun1, obj1, 2)
         hg.clear_all_attributes()
 
     def test_auto_cache_rename_attribute(self):
-        global crash_provider1
+        global crash_fun1
         obj1 = Dummy(1)
-        crash_provider1 = False
-        self.assertTrue(provider1(obj1, "aa", attribute_name="xxx") == 1)
-        crash_provider1 = True
-        self.assertRaises(Exception, provider1, obj1, "aa")
-        self.assertTrue(provider1(obj1, "aa", attribute_name="xxx") == 1)
+        crash_fun1 = False
+        self.assertTrue(fun1(obj1, "aa", attribute_name="xxx") == 1)
+        crash_fun1 = True
+        self.assertRaises(Exception, fun1, obj1, "aa")
+        self.assertTrue(fun1(obj1, "aa", attribute_name="xxx") == 1)
         hg.clear_all_attributes()
 
     def test_argument_helper_accept_everything(self):


### PR DESCRIPTION
It appears that the benefit of this decorator are rather limited (too many limitations on practical usage) compared to the burden created by the non standard handling of associated attributes in function calls.