### PR TITLE
Avoid watershed hierarchy calling specialized cpp functions

### DIFF
--- a/higra/hierarchy/py_watershed_hierarchy.cpp
+++ b/higra/hierarchy/py_watershed_hierarchy.cpp
@@ -40,58 +40,6 @@ struct def_watershed_hierarchy_by_attribute {
 };
 
 template<typename graph_t>
-struct def_watershed_hierarchy_by_dynamics {
-    template<typename value_t, typename C>
-    static
-    void def(C &c, const char *doc) {
-        c.def("_watershed_hierarchy_by_dynamics",
-              [](const graph_t &graph,
-                 const pyarray<value_t> &edge_weights) {
-                  return hg::watershed_hierarchy_by_dynamics(graph, edge_weights);
-              },
-              doc,
-              py::arg("graph"),
-              py::arg("edge_weights"));
-    }
-};
-
-template<typename graph_t>
-struct def_watershed_hierarchy_by_area {
-    template<typename value_t, typename C>
-    static
-    void def(C &c, const char *doc) {
-        c.def("_watershed_hierarchy_by_area",
-              [](const graph_t &graph,
-                 const pyarray<value_t> &edge_weights,
-                 const pyarray<double> &vertex_area) {
-                  return hg::watershed_hierarchy_by_area(graph, edge_weights, vertex_area);
-              },
-              doc,
-              py::arg("graph"),
-              py::arg("edge_weights"),
-              py::arg("vertex_area"));
-    }
-};
-
-template<typename graph_t>
-struct def_watershed_hierarchy_by_volume {
-    template<typename value_t, typename C>
-    static
-    void def(C &c, const char *doc) {
-        c.def("_watershed_hierarchy_by_volume",
-              [](const graph_t &graph,
-                 const pyarray<value_t> &edge_weights,
-                 const pyarray<double> &vertex_area) {
-                  return hg::watershed_hierarchy_by_volume(graph, edge_weights, vertex_area);
-              },
-              doc,
-              py::arg("graph"),
-              py::arg("edge_weights"),
-              py::arg("vertex_area"));
-    }
-};
-
-template<typename graph_t>
 struct def_watershed_hierarchy_by_minima_ordering {
     template<typename value_t, typename C>
     static
@@ -118,12 +66,6 @@ void py_init_watershed_hierarchy(pybind11::module &m) {
     add_type_overloads<def_watershed_hierarchy_by_attribute<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "");
 
     add_type_overloads<def_watershed_hierarchy_by_minima_ordering<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "");
-
-    add_type_overloads<def_watershed_hierarchy_by_dynamics<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "");
-
-    add_type_overloads<def_watershed_hierarchy_by_area<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "");
-
-    add_type_overloads<def_watershed_hierarchy_by_volume<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "");
 }
 
 

--- a/higra/hierarchy/watershed_hierarchy.py
+++ b/higra/hierarchy/watershed_hierarchy.py
@@ -38,14 +38,8 @@ def watershed_hierarchy_by_area(graph, edge_weights, vertex_area=None):
 
     vertex_area = hg.linearize_vertex_weights(vertex_area, graph)
 
-    vertex_area = hg.cast_to_dtype(vertex_area, np.float64)
-    res = hg.cpp._watershed_hierarchy_by_area(graph, edge_weights, vertex_area)
-    tree = res.tree()
-    altitudes = res.altitudes()
-
-    hg.CptHierarchy.link(tree, graph)
-
-    return tree, altitudes
+    return watershed_hierarchy_by_attribute(graph, edge_weights,
+                                            lambda tree, _: hg.attribute_area(tree, vertex_area, graph))
 
 
 def watershed_hierarchy_by_volume(graph, edge_weights, vertex_area=None):
@@ -74,14 +68,11 @@ def watershed_hierarchy_by_volume(graph, edge_weights, vertex_area=None):
 
     vertex_area = hg.linearize_vertex_weights(vertex_area, graph)
 
-    vertex_area = hg.cast_to_dtype(vertex_area, np.float64)
-    res = hg.cpp._watershed_hierarchy_by_volume(graph, edge_weights, vertex_area)
-    tree = res.tree()
-    altitudes = res.altitudes()
-
-    hg.CptHierarchy.link(tree, graph)
-
-    return tree, altitudes
+    return watershed_hierarchy_by_attribute(graph, edge_weights,
+                                            lambda tree, altitudes:
+                                            hg.attribute_volume(tree,
+                                                                altitudes,
+                                                                hg.attribute_area(tree, vertex_area)))
 
 
 def watershed_hierarchy_by_dynamics(graph, edge_weights):
@@ -104,13 +95,11 @@ def watershed_hierarchy_by_dynamics(graph, edge_weights):
     :param edge_weights: input graph edge weights
     :return: a tree (Concept :class:`~higra.CptHierarchy`) and its node altitudes
     """
-    res = hg.cpp._watershed_hierarchy_by_dynamics(graph, edge_weights)
-    tree = res.tree()
-    altitudes = res.altitudes()
-
-    hg.CptHierarchy.link(tree, graph)
-
-    return tree, altitudes
+    return watershed_hierarchy_by_attribute(graph, edge_weights,
+                                            lambda tree, altitudes:
+                                            hg.attribute_dynamics(tree,
+                                                                  altitudes,
+                                                                  "increasing"))
 
 
 def watershed_hierarchy_by_number_of_parents(graph, edge_weights):
@@ -197,7 +186,7 @@ def watershed_hierarchy_by_attribute(graph, edge_weights, attribute_functor):
 
     .. code-block:: python
 
-        tree = watershed_hierarchy_by_attribute(graph, lambda tree, _: hg.attribute_area(tree))
+        tree = watershed_hierarchy_by_attribute(graph, edge_weights, lambda tree, _: hg.attribute_area(tree))
 
     :param graph: input graph
     :param edge_weights: edge weights of the input graph


### PR DESCRIPTION
reduces compile time of bindings and library size