### PR TITLE
fix wrong overload resolution in labelisation_seeded_watershed

### DIFF
--- a/higra/algo/watershed.py
+++ b/higra/algo/watershed.py
@@ -67,6 +67,8 @@ def labelisation_seeded_watershed(graph, edge_weights, vertex_seeds, background_
 
     vertex_seeds = hg.linearize_vertex_weights(vertex_seeds, graph)
 
+    vertex_seeds = hg.cast_to_dtype(vertex_seeds, np.int64)
+
     labels = hg.cpp._labelisation_seeded_watershed(graph, edge_weights, vertex_seeds, background_label)
 
     labels = hg.delinearize_vertex_weights(labels, graph)

--- a/test/python/test_algo/test_watershed.py
+++ b/test/python/test_algo/test_watershed.py
@@ -56,6 +56,23 @@ class TestWatershed(unittest.TestCase):
                                (2, 2, 3, 3)))
         self.assertTrue(np.all(labels == expected))
 
+    def test_seeded_watershed_type_conversion(self):
+        g = hg.get_4_adjacency_graph((4, 4))
+        edge_weights = np.asarray((1, 2, 5, 5, 4, 8, 1, 4, 3, 4, 4, 1, 5, 2, 6, 2, 5, 2, 0, 7, 0, 3, 4, 0)) / 10.0
+
+        seeds = np.asarray(((1, 1, 0, 0),
+                            (1, 0, 0, 0),
+                            (0, 0, 0, 0),
+                            (1, 1, 2, 2)), dtype=np.int32)
+
+        labels = hg.labelisation_seeded_watershed(g, edge_weights, seeds)
+
+        expected = np.asarray(((1, 1, 2, 2),
+                               (1, 1, 2, 2),
+                               (1, 1, 2, 2),
+                               (1, 1, 2, 2)))
+        self.assertTrue(np.all(labels == expected))
+
     def test_seeded_watershed_split_minima(self):
         g = hg.get_4_adjacency_graph((2, 4))
         edge_weights = np.asarray((0, 1, 0, 2, 0, 2, 0, 1, 2, 1))


### PR DESCRIPTION
when seeds are not of type np.int64