### PR TITLE
Refactor watershed hierarchy

### DIFF
--- a/higra/hierarchy/hierarchy_core.py
+++ b/higra/hierarchy/hierarchy_core.py
@@ -115,7 +115,7 @@ def saliency(tree, altitudes, leaf_graph, handle_rag=True):
     return sm
 
 
-def canonize_hierarchy(tree, altitudes):
+def canonize_hierarchy(tree, altitudes, return_node_map=False):
     """
     Removes consecutive tree nodes with equal altitudes.
 
@@ -125,13 +125,21 @@ def canonize_hierarchy(tree, altitudes):
     For example, applying this function to the result of :func:`~higra.bpt_canonical` on an edge weighted graph
     is the same as computing the :func:`~higra.quasi_flat_zone_hierarchy` of the same edge weighted graph.
 
+    If :attr:`return_node_map` is ``True``, an extra array that maps any vertex index :math:`i` of the new tree,
+    to the index of the corresponding vertex in the original tree is returned.
+
     :param tree: input tree
     :param altitudes: altitudes of the vertices of the tree
+    :param return_node_map: if ``True``, also return the node map.
     :return: a tree (Concept :class:`~higra.CptHierarchy` if input tree already satisfied this concept)
-            and its node altitudes
+             its node altitudes, and, if requested, its node map.
     """
-    ctree, node_map = hg.simplify_tree(tree, altitudes == altitudes[tree.parents()])
-    return ctree, altitudes[node_map]
+    tree, node_map = hg.simplify_tree(tree, altitudes == altitudes[tree.parents()])
+    new_altitudes = altitudes[node_map]
+    if return_node_map:
+        return tree, new_altitudes, node_map
+    else:
+        return tree, new_altitudes
 
 
 def tree_2_binary_tree(tree):

--- a/higra/hierarchy/py_hierarchy_core.cpp
+++ b/higra/hierarchy/py_hierarchy_core.cpp
@@ -30,13 +30,17 @@ struct def_node_weighted_tree_and_mst {
                                      (std::string("NodeWeightedTreeAndMST_") + typeid(class_t).name()).c_str(),
                                      "A simple structure to hold the result of canonical bpt construction algorithms, "
                                      "namely a tree, its associated node altitude array, and its associated MST.");
-        c.def("tree", [](class_t &self) -> tree_t & { return self.tree; }, "The binary partition tree!");
+        c.def("tree", [](class_t &self) -> tree_t & { return self.tree; }, "The binary partition tree!",
+                py::return_value_policy::reference_internal);
         c.def("altitudes", [](class_t &self) -> hg::array_1d<value_t> & { return self.altitudes; },
-              "An array of tree node altitude.");
+              "An array of tree node altitude.",
+              py::return_value_policy::reference_internal);
         c.def("mst", [](class_t &self) -> hg::ugraph & { return self.mst; },
-              "A minimum spanning tree associated to the binary partition tree.");
+              "A minimum spanning tree associated to the binary partition tree.",
+              py::return_value_policy::reference_internal);
         c.def("mst_edge_map", [](class_t &self) -> hg::array_1d<hg::index_t> & { return self.mst_edge_map; },
-              "For each edge index i of the mst, gives the corresponding edge index in the original graph.");
+              "For each edge index i of the mst, gives the corresponding edge index in the original graph.",
+              py::return_value_policy::reference_internal);
     }
 };
 

--- a/higra/hierarchy/py_watershed_hierarchy.cpp
+++ b/higra/hierarchy/py_watershed_hierarchy.cpp
@@ -47,16 +47,19 @@ struct def_watershed_hierarchy_by_minima_ordering {
         c.def("_watershed_hierarchy_by_minima_ordering",
               [](const graph_t &graph,
                  const pyarray<value_t> &edge_weights,
-                 const pyarray<size_t> &minima_ranks,
-                 const pyarray<double> &minima_altitudes) {
-                  return hg::watershed_hierarchy_by_minima_ordering(graph, edge_weights, minima_ranks,
-                                                                    minima_altitudes);
+                 const pyarray<size_t> &minima_ranks) {
+                  auto res = hg::watershed_hierarchy_by_minima_ordering(graph, edge_weights, minima_ranks);
+                  return py::make_tuple(
+                          std::move(res.tree),
+                          std::move(res.altitudes),
+                          std::move(res.mst),
+                          std::move(res.mst_edge_map)
+                          );
               },
               doc,
               py::arg("graph"),
               py::arg("edge_weights"),
-              py::arg("minima_ranks"),
-              py::arg("minima_ordering"));
+              py::arg("minima_ranks"));
     }
 };
 

--- a/test/cpp/hierarchy/test_watershed_hierarchy.cpp
+++ b/test/cpp/hierarchy/test_watershed_hierarchy.cpp
@@ -31,11 +31,11 @@ namespace watershed_hierarchy {
         auto &t = res.tree;
         auto &altitudes = res.altitudes;
 
-        array_1d<index_t> ref_parents{7, 7, 6, 7, 7, 6, 8, 8, 8};
-        tree ref_tree(ref_parents);
-        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 2};
+        array_1d<index_t> ref_parents{6, 7, 8, 6, 7, 8, 9, 9, 10, 10, 10 };
 
-        REQUIRE(test_tree_isomorphism(t, ref_tree));
+        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2};
+
+        REQUIRE((ref_parents == t.parents()));
         REQUIRE((altitudes == ref_altitudes));
     }
 
@@ -48,14 +48,12 @@ namespace watershed_hierarchy {
         auto &t = res.tree;
         auto &altitudes = res.altitudes;
 
-        array_1d<index_t> ref_parents{19, 19, 20, 20, 20, 21, 21, 21, 21, 21, 21, 22, 22, 22, 22, 22, 23, 23, 23,
-                                      24,
-                                      24, 25, 26, 26, 25, 27, 27, 27};
-        tree ref_tree(ref_parents);
-        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3,
-                                    5};
+        array_1d<index_t> ref_parents{19, 19, 20, 20, 21, 22, 22, 23, 24, 25, 26, 27, 27, 28, 29, 30, 31, 31, 32,
+                                      33, 21, 33, 23, 24, 25, 26, 34, 28, 29, 30, 35, 32, 35, 34, 36, 36, 36};
+        array_1d<int> ref_altitudes  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3, 5};
 
-        REQUIRE(test_tree_isomorphism(t, ref_tree));
+        REQUIRE((ref_parents == t.parents()));
         REQUIRE((altitudes == ref_altitudes));
     }
 
@@ -78,11 +76,12 @@ namespace watershed_hierarchy {
         auto &t = res.tree;
         auto &altitudes = res.altitudes;
 
-        array_1d<index_t> ref_parents{7, 7, 8, 8, 8, 9, 9, 11, 10, 10, 11, 11};
-        tree ref_tree(ref_parents);
-        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
+        array_1d<index_t> ref_parents{8, 8, 9, 7, 7, 10, 10,
+                                      9, 12, 11, 11, 12, 12};
+        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 2, 3};
 
-        REQUIRE(test_tree_isomorphism(t, ref_tree));
+        REQUIRE((ref_parents == t.parents()));
         REQUIRE((altitudes == ref_altitudes));
     }
 
@@ -96,11 +95,12 @@ namespace watershed_hierarchy {
         auto &t = res.tree;
         auto &altitudes = res.altitudes;
 
-        array_1d<index_t> ref_parents{7, 7, 8, 8, 8, 9, 9, 11, 10, 10, 11, 11};
-        tree ref_tree(ref_parents);
-        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6};
+        array_1d<index_t> ref_parents{8, 8, 9, 7, 7, 10, 10,
+                                      9, 12, 11, 11, 12, 12};
+        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 4, 6};
 
-        REQUIRE(test_tree_isomorphism(t, ref_tree));
+        REQUIRE((ref_parents == t.parents()));
         REQUIRE((altitudes == ref_altitudes));
     }
 
@@ -110,17 +110,17 @@ namespace watershed_hierarchy {
         array_1d<int> edge_weights{1, 4, 1, 0, 10, 8};
         //same as dynamics
         array_1d<int> minima_ranking{2, 2, 0, 3, 3, 1, 1};
-        array_1d<int> minima_altitudes{0, 2, 3, 10};
 
-        auto res = watershed_hierarchy_by_minima_ordering(g, edge_weights, minima_ranking, minima_altitudes);
+        auto res = watershed_hierarchy_by_minima_ordering(g, edge_weights, minima_ranking);
         auto &t = res.tree;
         auto &altitudes = res.altitudes;
 
-        array_1d<index_t> ref_parents{7, 7, 8, 8, 8, 9, 9, 11, 10, 10, 11, 11};
-        tree ref_tree(ref_parents);
-        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
+        array_1d<index_t> ref_parents{8, 8, 9, 7, 7, 10, 10,
+                                      9, 12, 11, 11, 12, 12};
+        array_1d<int> ref_altitudes{0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 1, 2};
 
-        REQUIRE(test_tree_isomorphism(t, ref_tree));
+        REQUIRE((ref_parents == t.parents()));
         REQUIRE((altitudes == ref_altitudes));
     }
 

--- a/test/python/test_hierarchy/test_hierarchy_core.py
+++ b/test/python/test_hierarchy/test_hierarchy_core.py
@@ -167,13 +167,16 @@ class TestHierarchyCore(unittest.TestCase):
         t = TestHierarchyCore.getTree()
         altitudes = np.asarray((0, 0, 0, 0, 0, 1, 2, 2))
 
-        new_tree, new_altitudes = hg.canonize_hierarchy(t, altitudes)
+        new_tree, new_altitudes, node_map = hg.canonize_hierarchy(t, altitudes, return_node_map=True)
 
         refp = np.asarray((5, 5, 6, 6, 6, 6, 6))
         self.assertTrue(np.all(refp == new_tree.parents()))
 
         refa = np.asarray((0, 0, 0, 0, 0, 1, 2))
         self.assertTrue(np.all(refa == new_altitudes))
+
+        refm = np.asarray((0, 1, 2, 3, 4, 5, 7))
+        self.assertTrue(np.all(refm == node_map))
 
     def test_tree_2_binary_tree(self):
         t = hg.Tree((9, 9, 10, 10, 10, 10, 11, 11, 11, 12, 12, 12, 12))

--- a/test/python/test_hierarchy/test_watershed_hierarchy.py
+++ b/test/python/test_hierarchy/test_watershed_hierarchy.py
@@ -43,6 +43,19 @@ class TestWatershedHierarchy(unittest.TestCase):
         ref_tree = hg.Tree(ref_parents)
         ref_altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3))
 
+        self.assertTrue(hg.CptHierarchy.validate(t))
+        self.assertTrue(hg.test_tree_isomorphism(t, ref_tree))
+        self.assertTrue(np.allclose(altitudes, ref_altitudes))
+
+        # binary watershed hierarchy
+        t, altitudes = hg.watershed_hierarchy_by_minima_ordering(g, edge_weights, minima_ranking, minima_altitudes=None, canonize_tree=False)
+
+        ref_parents = np.asarray((8, 8, 9, 7, 7, 10, 10,
+                                  9, 12, 11, 11, 12, 12))
+        ref_tree = hg.Tree(ref_parents)
+        ref_altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 1, 2))
+        self.assertTrue(hg.CptBinaryHierarchy.validate(t))
         self.assertTrue(hg.test_tree_isomorphism(t, ref_tree))
         self.assertTrue(np.allclose(altitudes, ref_altitudes))
 
@@ -57,6 +70,20 @@ class TestWatershedHierarchy(unittest.TestCase):
         ref_tree = hg.Tree(ref_parents)
         ref_altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3, 5))
 
+        self.assertTrue(hg.CptHierarchy.validate(tree))
+        self.assertTrue(hg.test_tree_isomorphism(tree, ref_tree))
+        self.assertTrue(np.allclose(altitudes, ref_altitudes))
+
+        # binary watershed hierarchy
+        tree, altitudes = hg.watershed_hierarchy_by_area(g, edge_weights, canonize_tree=False)
+
+        ref_parents = np.asarray((19, 19, 20, 20, 21, 22, 22, 23, 24, 25, 26, 27, 27, 28, 29, 30, 31, 31, 32,
+                                  33, 21, 33, 23, 24, 25, 26, 34, 28, 29, 30, 35, 32, 35, 34, 36, 36, 36), dtype=np.int64)
+        ref_tree = hg.Tree(ref_parents)
+        ref_altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3, 5))
+
+        self.assertTrue(hg.CptBinaryHierarchy.validate(tree))
         self.assertTrue(hg.test_tree_isomorphism(tree, ref_tree))
         self.assertTrue(np.allclose(altitudes, ref_altitudes))
 


### PR DESCRIPTION
- python canonize_tree can now return the node map
- cpp watershed hierarchy functions now return the binary partition hierarchy with its mst
- python watershed hierarchy functions can return the binary partition hierarchy with its mst or the canonized tree (default)