### PR TITLE
Lca fast based on RMQ with block decomposition

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -70,7 +70,8 @@ include_directories(${GBENCHMARK_INCLUDE_DIRS})
 set(FILES_BENCHMARK
         main.cpp
         utils.cpp
-        benchmark_undirected_graph.cpp
+        benchmark_lca.cpp
+        #benchmark_undirected_graph.cpp
         #benchmark_regular_graph.cpp
         #benchmark_accumulator.cpp
         #benchmark_parallel_sort.cpp
@@ -88,5 +89,5 @@ target_link_libraries(${BENCHMARK_TARGET} benchmark -lpthread ${TBB_LIBRARIES})
 
 
 add_custom_target(benchmark_exe
-        COMMAND benchmarkx
+        COMMAND benchmark_higra
         DEPENDS ${BENCHMARK_TARGET})

--- a/benchmark/benchmark_lca.cpp
+++ b/benchmark/benchmark_lca.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2021)                                             *
+*                                                                          *
+* Contributor(s) : Benjamin Perret                                         *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+
+#include <benchmark/benchmark.h>
+#include "utils.h"
+
+#include "higra/image/graph_image.hpp"
+#include "higra/hierarchy/hierarchy_core.hpp"
+#include "higra/hierarchy/watershed_hierarchy.hpp"
+#include "xtensor/xrandom.hpp"
+#include "higra/structure/lca_fast.hpp"
+
+using namespace xt;
+using namespace hg;
+
+index_t repetition = 1;
+
+static void BM_lca_sparse_table_block(benchmark::State &state) {
+    for (auto _ : state) {
+        for(index_t i = 0; i < repetition; i++){
+            state.PauseTiming();
+
+            index_t size = state.range(0);
+            index_t bsize = state.range(1);
+
+
+            auto g = get_4_adjacency_graph({size, size});
+            array_1d<double> weights = xt::random::rand<double>({num_edges(g)});
+            auto res = watershed_hierarchy_by_area(g, weights);
+            auto & tree = res.tree;
+
+            state.ResumeTiming();
+            lca_sparse_table_block l(tree, bsize);
+            auto ll = l.lca(sources(g), targets(g));
+
+            benchmark::DoNotOptimize(ll[0]);
+        }
+    }
+}
+
+
+static void gridSearch(benchmark::internal::Benchmark* b) {
+    for (index_t i = 256; i <= 2048; i+=256)
+        for (int j = 32; j <= 4096; j *= 2)
+            b->Args({i, j});
+}
+
+
+BENCHMARK(BM_lca_sparse_table_block)->Apply(gridSearch);
+
+
+
+static void BM_lca_sparse_table(benchmark::State &state) {
+    for (auto _ : state) {
+        for(index_t i = 0; i < repetition; i++){
+            state.PauseTiming();
+
+            index_t size = state.range(0);
+
+            auto g = get_4_adjacency_graph({size, size});
+            array_1d<double> weights = xt::random::rand<double>({num_edges(g)});
+            auto res = watershed_hierarchy_by_area(g, weights);
+            auto & tree = res.tree;
+
+            state.ResumeTiming();
+            lca_sparse_table l(tree);
+            auto ll = l.lca(sources(g), targets(g));
+
+            benchmark::DoNotOptimize(ll[0]);
+        }
+    }
+}
+
+BENCHMARK(BM_lca_sparse_table)->DenseRange(256, 2048, 256);

--- a/higra/structure/lca_fast.py
+++ b/higra/structure/lca_fast.py
@@ -15,18 +15,28 @@ def make_lca_fast(tree):
     """
     Deprecated: please use :func:`~higra.Tree.lowest_common_ancestor_preprocess`
 
-    Create an object of type :class:`~higra.LCAFast` for the given tree
-
     :param tree: input tree
-    :return: a LCAFast object
+    :return:
     """
     return tree.lowest_common_ancestor_preprocess()
 
 
-def __reduce_ctr(*args):
-    return hg.LCAFast._make_from_state(*args)
+def __reduce_ctr_lca_st(*args):
+    return hg.LCA_rmq_sparse_table._make_from_state(args)
 
 
-@hg.extend_class(hg.LCAFast, method_name="__reduce__")
+def __reduce_ctr_lca_stb(*args):
+    return hg.LCA_rmq_sparse_table_block._make_from_state(args)
+
+
+@hg.extend_class(hg.LCA_rmq_sparse_table, method_name="__reduce__")
 def ____reduce__(self):
-    return __reduce_ctr, self._get_state(), self.__dict__
+    return __reduce_ctr_lca_st, self._get_state(), self.__dict__
+
+
+@hg.extend_class(hg.LCA_rmq_sparse_table_block, method_name="__reduce__")
+def ____reduce__(self):
+    return __reduce_ctr_lca_stb, self._get_state(), self.__dict__
+
+
+#LCAFast = hg.LCA_rmq_sparse_table_block

--- a/higra/structure/py_lca_fast.cpp
+++ b/higra/structure/py_lca_fast.cpp
@@ -21,18 +21,22 @@ using namespace hg;
 template<typename T>
 using pyarray = xt::pyarray<T>;
 
+template<typename T>
+using pyarray_1d = xt::pytensor<T, 1>;
+
+template<typename lca_t>
 struct def_lca_vertices {
     template<typename value_t, typename C>
     static
     void def(C &c, const char *doc) {
-        c.def("lca", [](const lca_fast &l,
+        c.def("lca", [](const lca_t &l,
                         const pyarray<value_t> &vertices1,
                         const pyarray<value_t> &vertices2) {
                   hg_assert((xt::amin)(vertices1)() >= 0, "Vertex indices cannot be negative.");
-                  hg_assert((index_t) (index_t) (xt::amax)(vertices1)() < (index_t) l.num_vertices(),
+                  hg_assert((index_t) (index_t) (xt::amax)(vertices1)() < (index_t) l.num_elements(),
                             "Vertex indices must be smaller than the number of vertices in the tree.");
                   hg_assert((xt::amin)(vertices2)() >= 0, "Vertex indices cannot be negative.");
-                  hg_assert((index_t) (xt::amax)(vertices2)() < (index_t) l.num_vertices(),
+                  hg_assert((index_t) (xt::amax)(vertices2)() < (index_t) l.num_elements(),
                             "Vertex indices must be smaller than the number of vertices in the tree.");
                   return l.lca(vertices1, vertices2);
               },
@@ -42,12 +46,81 @@ struct def_lca_vertices {
     }
 };
 
-void py_init_lca_fast(pybind11::module &m) {
-    xt::import_numpy();
-    auto c = py::class_<lca_fast>(m, "LCAFast",
-                                  "Provides fast :math:`\\mathcal{O}(1)` lowest common ancestor computation in a tree thanks "
-                                  "to a linearithmic preprocessing of the tree.",
-                                  py::dynamic_attr());
+using namespace range_minimum_query_internal;
+
+
+auto get_rmq_state_to_python(const rmq_sparse_table<index_t>::internal_state<array_1d> &state) {
+    py::list list;
+    for (auto &t: state.sparse_table) {
+        list.append(std::move(t));
+    }
+    return list;
+}
+
+
+auto get_rmq_state_to_python(const rmq_sparse_table_block<index_t>::internal_state<array_1d> &state) {
+    py::list list;
+
+    list.append(state.data_size);
+    list.append(state.block_size);
+    list.append(state.num_blocks);
+    list.append(std::move(state.block_minimum_prefix));
+    list.append(std::move(state.block_minimum_suffix));
+    list.append(get_rmq_state_to_python(state.sparse_table));
+
+    return list;
+}
+
+template<typename rmq_t>
+auto get_rmq_state_from_python(const py::list &list);
+
+template<>
+auto get_rmq_state_from_python<range_minimum_query_internal::rmq_sparse_table<index_t>>(const py::list &list) {
+
+    std::vector<pyarray_1d<size_t>> sp;
+    for (auto &e: list) {
+        sp.push_back(e.template cast<pyarray_1d<size_t>>());
+    }
+    return range_minimum_query_internal::rmq_sparse_table<index_t>::internal_state<pyarray_1d>(sp);
+}
+
+template<>
+auto get_rmq_state_from_python<range_minimum_query_internal::rmq_sparse_table_block<index_t>>(const py::list &list) {
+    return range_minimum_query_internal::rmq_sparse_table_block<index_t>::internal_state<pyarray_1d>(
+            list[0].template cast<index_t>(),
+            list[1].template cast<index_t>(),
+            list[2].template cast<index_t>(),
+            list[3].template cast<pyarray_1d<index_t>>(),
+            list[4].template cast<pyarray_1d<index_t>>(),
+            get_rmq_state_from_python<range_minimum_query_internal::rmq_sparse_table<index_t>>(
+                    list[5].template cast<py::list>())
+    );
+}
+
+template<typename T>
+auto get_lca_state_to_python(const T &state) {
+    py::list list;
+    list.append(std::move(state.tree_Euler_tour_map));
+    list.append(std::move(state.tree_Euler_tour_depth));
+    list.append(std::move(state.first_visit_in_Euler_tour));
+    list.append(get_rmq_state_to_python(state.rmq_state));
+    return list;
+}
+
+template<typename lca_t>
+auto get_lca_state_from_python(const py::list &list) {
+    using state_type = typename lca_t::template internal_state<pyarray_1d>;
+    return state_type(
+            list[0].template cast<pyarray_1d<index_t>>(),
+            list[1].template cast<pyarray_1d<index_t>>(),
+            list[2].template cast<pyarray_1d<index_t>>(),
+            get_rmq_state_from_python<typename lca_t::rmq_type>(list[3])
+    );
+}
+
+template<typename lca_t, typename T>
+auto def_lca_t(T &m, const char *name, const char *doc) {
+    auto c = py::class_<lca_t>(m, name, doc, py::dynamic_attr());
 
     c.def(py::init<tree>(),
           "Preprocess the given tree in order for fast lowest common ancestor (LCA) computation.\n\n"
@@ -56,9 +129,9 @@ void py_init_lca_fast(pybind11::module &m) {
           py::arg("tree"));
 
     c.def("lca",
-          [](const lca_fast &l, index_t v1, index_t v2) {
+          [](const lca_t &l, index_t v1, index_t v2) {
               hg_assert(v1 >= 0 && v2 >= 0, "Vertex indices cannot be negative.");
-              hg_assert(v1 < (index_t) l.num_vertices() && v2 < (index_t) l.num_vertices(),
+              hg_assert(v1 < (index_t) l.num_elements() && v2 < (index_t) l.num_elements(),
                         "Vertex indices must be smaller than the number of vertices in the tree.");
               return l.lca(v1, v2);
           },
@@ -67,45 +140,53 @@ void py_init_lca_fast(pybind11::module &m) {
           py::arg("v2"));
 
     c.def("lca",
-          [](const lca_fast &l, const ugraph &g) { return l.lca(edge_iterator(g)); },
+          [](const lca_t &l, const ugraph &g) { return l.lca(edge_iterator(g)); },
           "Compute the LCA of every edge of the given graph.",
           py::arg("UndirectedGraph"));
 
-    add_type_overloads<def_lca_vertices, int, unsigned int, long long, unsigned long long>
+    add_type_overloads<def_lca_vertices<lca_t>, int, unsigned int, long long, unsigned long long>
             (c, "Given two 1d array of graph vertex indices v1 and v2, both containing n elements, "
                 "this function returns a 1d array or tree vertex indices of size n such that: \n"
                 "for all i in 0..n-1, res(i) = lca(v1(i); v2(i)).");
 
     c.def("_get_state",
-          [](const lca_fast &l) {
-              auto state = l.get_state();
-              return py::make_tuple(
-                      state.m_num_vertices,
-                      std::move(state.m_Euler),
-                      std::move(state.m_Depth),
-                      std::move(state.m_Represent),
-                      std::move(state.m_Number),
-                      std::move(state.m_Minim),
-                      state.m_rep);
+          [](const lca_t &l) {
+              return py::make_tuple(get_lca_state_to_python(l.get_state()));
           },
           "Return an opaque structure representing the internal state of the object");
 
-
     c.def_static("_make_from_state",
-                 [](size_t &a0,
-                    const pyarray<index_t> &a1,
-                    const pyarray<index_t> &a2,
-                    const pyarray<index_t> &a3,
-                    const pyarray<index_t> &a4,
-                    const pyarray<index_t> &a5,
-                    size_t &a6) {
-
-                     return hg::lca_fast::make_lca_fast(
-                             lca_fast::internal_state<pyarray<index_t>, pyarray<index_t>>(
-                                     a0, a1, a2, a3, a4, a5, a6));
-
+                 [](py::tuple &t) {
+                     return lca_t::make_from_state(get_lca_state_from_python<lca_t>(t[0].template cast<py::list>()));
                  },
                  "Create a new lca_fast object from the saved state (see function get_state)");
 
+    return c;
+}
+
+
+void py_init_lca_fast(pybind11::module &m) {
+    xt::import_numpy();
+
+    auto c_lca_sp = def_lca_t<lca_sparse_table>(
+            m, "LCA_rmq_sparse_table",
+            "Provides fast :math:`\\mathcal{O}(1)` lowest common ancestor computation in a tree thanks "
+            "to a linearithmic preprocessing of the tree.");
+
+    auto c_lca_spb = def_lca_t<lca_sparse_table_block>(
+            m, "LCA_rmq_sparse_table_block",
+            "Provides fast :math:`\\mathcal{O}(1)` lowest common ancestor computation in a tree thanks "
+            "to a linear preprocessing of the tree.");
+
+    c_lca_spb.def(py::init([](const tree & t, size_t block_size){
+        return lca_sparse_table_block(t, block_size);
+        }),
+          "Preprocess the given tree in order for fast lowest common ancestor (LCA) computation.\n\n"
+          "Consider using the function :func:`~higra.Tree.lowest_ancestor_preprocess` instead of calling this constructor to"
+          "avoid preprocessing the same tree several times.",
+          py::arg("tree"),
+          py::arg("block_size"));
+
+    // @TODO export symbol LCAFast python
 
 }

--- a/include/higra/hierarchy/watershed_hierarchy.hpp
+++ b/include/higra/hierarchy/watershed_hierarchy.hpp
@@ -158,7 +158,7 @@ namespace hg {
         return watershed_hierarchy_by_attribute(
                 graph,
                 edge_weights,
-                [&vertex_area](const tree &t, const auto &altitude) {
+                [&vertex_area](const tree &t, const auto &) {
                     return attribute_area(t, vertex_area);
                 });
     };

--- a/include/higra/structure/details/range_minimum_query.hpp
+++ b/include/higra/structure/details/range_minimum_query.hpp
@@ -1,0 +1,369 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2021)                                             *
+*                                                                          *
+* Contributor(s) : Benjamin Perret                                         *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#pragma once
+
+#include "higra/structure/array.hpp"
+#include <vector>
+
+
+namespace hg {
+
+    namespace range_minimum_query_internal {
+        /*
+         * The 2 following classes rmq_sparse_table and rmq_sparse_table_block are freely adapted from
+         * https://github.com/wx-csy/librmq (release 2.0 on Jul 28, 2019, commit 32bac30f1a1e1debf482a0477098bd0db203d849)
+         * published under the MIT license reproduced hereafter:
+         *
+         * MIT License
+         *
+         * Copyright (c) 2019 Shaoyuan CHEN
+         *
+         * Permission is hereby granted, free of charge, to any person obtaining a copy
+         * of this software and associated documentation files (the "Software"), to deal
+         * in the Software without restriction, including without limitation the rights
+         * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+         * copies of the Software, and to permit persons to whom the Software is
+         * furnished to do so, subject to the following conditions:
+         *
+         * The above copyright notice and this permission notice shall be included in all
+         * copies or substantial portions of the Software.
+         *
+         * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+         * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+         * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+         * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+         * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+         * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+         * SOFTWARE.
+         *
+         */
+
+
+        /**
+         * RMQ based on sparse table :
+         * - O(n log(n)) preprocessing
+         * - O(1) query
+         * @tparam data_t
+         */
+        template<typename data_t>
+        struct rmq_sparse_table {
+            using self_type = rmq_sparse_table<data_t>;
+
+            rmq_sparse_table() {
+
+            }
+
+            template<typename T>
+            rmq_sparse_table(const T &values) : m_data(values.data()) {
+                index_t size = values.size();
+                reserve_sparse_table(size);
+                m_sparse_table.push_back(xt::arange<size_t>(0, size));
+                init_sparse_table();
+            }
+
+            template<typename T>
+            rmq_sparse_table(const T &values, array_1d <size_t> &&element_map) : m_data(values.data()) {
+                reserve_sparse_table(element_map.size());
+                m_sparse_table.push_back(std::move(element_map));
+                init_sparse_table();
+            }
+
+            template<typename T>
+            rmq_sparse_table(const T &values, const array_1d <size_t> &element_map) : m_data(values.data()) {
+                reserve_sparse_table(element_map.size());
+                m_sparse_table.push_back(element_map);
+                init_sparse_table();
+            }
+
+            /**
+             * Precondition l < r
+             * @param l
+             * @param r
+             * @return
+             */
+            index_t query(index_t l, index_t r) const {
+                auto level = fast_log2(r - l);
+                auto p1 = m_sparse_table[level](l);
+                auto p2 = m_sparse_table[level](r - (1 << level));
+                return m_data[p1] < m_data[p2] ? p1 : p2;
+            }
+
+            template<template<typename> typename container_t>
+            struct internal_state {
+                using type = self_type;
+                using array_t = container_t<size_t>;
+                using sp_t = std::vector<array_t>;
+                sp_t sparse_table;
+
+                internal_state(const sp_t &_sparse_table) :
+                        sparse_table(_sparse_table) {}
+
+                internal_state(sp_t && _sparse_table) :
+                        sparse_table(std::move(_sparse_table)) {}
+            };
+
+            auto get_state() const {
+                return internal_state<array_1d>(m_sparse_table);
+            }
+
+            template<template<typename> typename container_t, typename T>
+            static auto make_from_state(internal_state<container_t> &&state, const T &data) {
+                rmq_sparse_table<typename T::value_type> rmq;
+                rmq.template set_state(std::move(state), data);
+                return rmq;
+            }
+
+            template<template<typename> typename container_t, typename T>
+            static auto make_from_state(const internal_state<container_t> &state, const T &data) {
+                rmq_sparse_table<typename T::value_type> rmq;
+                rmq.template set_state(state, data);
+                return rmq;
+            }
+
+        private:
+
+            template<template<typename> typename container_t, typename T>
+            void set_state(internal_state<container_t> &&state, const T &data) {
+                m_sparse_table = std::move(state.sparse_table);
+                m_data = data.begin();
+            }
+
+            template<template<typename> typename container_t, typename T>
+            void set_state(const internal_state<container_t> &state, const T &data) {
+                m_sparse_table = state.sparse_table;
+                m_data = data.begin();
+            }
+
+            static inline size_t fast_log2(size_t length) {
+                return sizeof(size_t) * 8 - 1 - __builtin_clzll(length);
+            }
+
+            void reserve_sparse_table(size_t size) {
+                m_sparse_table.reserve((size_t) ceil(log((double) (size)) / log(2.0)));
+            }
+
+            void init_sparse_table() {
+                index_t size = m_sparse_table[0].size();
+
+                for (index_t lvl = 0; (2 << lvl) <= size; lvl++) {
+                    index_t size_lvlp1 = size - (2 << lvl) + 1;
+                    m_sparse_table.push_back(array_1d<index_t>::from_shape({(size_t) size_lvlp1}));
+                    parfor(0, size_lvlp1, [this, lvl](index_t i) {
+                        auto p1 = m_sparse_table[lvl](i);
+                        auto p2 = m_sparse_table[lvl](i + (1 << lvl));
+                        m_sparse_table[lvl + 1](i) = m_data[p1] < m_data[p2] ? p1 : p2;
+                    });
+                }
+            }
+
+            std::vector<array_1d < size_t>> m_sparse_table;
+            const data_t *m_data;
+        };
+
+        /**
+         * RMQ based on sparse table on blocks,
+         * - O(n) preprocessing (if block size is in  O(log(n)))
+         * - average O(1) query (for uniformly distributed queries)
+         * @tparam data_t
+         */
+        template<typename data_t>
+        struct rmq_sparse_table_block {
+
+            using self_type = rmq_sparse_table_block<data_t>;
+
+            rmq_sparse_table_block() {
+
+            }
+
+            template<typename T>
+            rmq_sparse_table_block(const T &values, size_t block_size = 512) : m_data(values.data()),
+                                                                               m_block_size(block_size) {
+                m_data_size = values.size();
+                m_num_blocks = (m_data_size + m_block_size - 1) / m_block_size;
+                m_block_minimum_prefix.resize({(size_t) (m_num_blocks * m_block_size)});
+                m_block_minimum_suffix.resize({(size_t) (m_num_blocks * m_block_size)});
+                init(values);
+            }
+
+            /**
+             * Precondition l < r
+             * @param l
+             * @param r
+             * @return
+             */
+            index_t query(index_t l, index_t r) const {
+
+
+                index_t lb = l / m_block_size;
+                index_t rb = r / m_block_size;
+                if (lb != rb) { // speculative policy
+                    index_t ret = m_sparse_table.query(lb, std::min(m_num_blocks, rb + 1));
+                    if (ret >= l and ret < r) return ret;
+                } else {
+                    if (m_block_minimum_prefix(r) >= l)
+                        return m_block_minimum_prefix(r);
+                    if (m_block_minimum_suffix(l) <= r)
+                        return m_block_minimum_suffix(l);
+                    return std::min_element(m_data + l, m_data + r) - m_data;
+                }
+                //index_t lbase = lb * m_block_size;
+                index_t rbase = rb * m_block_size;
+                index_t v = m_block_minimum_suffix(l);
+                if (r != rbase) {
+                    index_t v2 = m_block_minimum_prefix(r - 1);
+                    if (m_data[v2] < m_data[v]) v = v2;
+                }
+                if (lb + 1 == rb) return v;
+                index_t vv = m_sparse_table.query(lb + 1, rb);
+                return m_data[vv] < m_data[v] ? vv : v;
+            }
+
+            template<template<typename> typename container_t>
+            struct internal_state {
+                using type = self_type;
+                using sp_state_type = typename rmq_sparse_table<data_t>::template internal_state<container_t>;
+                index_t data_size;
+                index_t block_size;
+                index_t num_blocks;
+                container_t<index_t> block_minimum_prefix;
+                container_t<index_t> block_minimum_suffix;
+                sp_state_type sparse_table;
+
+                internal_state(index_t _data_size,
+                               index_t _block_size,
+                               index_t _num_blocks,
+                               container_t<index_t> &&_block_minimum_prefix,
+                               container_t<index_t> &&_block_minimum_suffix,
+                               sp_state_type &&_sp_state) :
+                        data_size(_data_size),
+                        block_size(_block_size),
+                        num_blocks(_num_blocks),
+                        block_minimum_prefix(std::move(_block_minimum_prefix)),
+                        block_minimum_suffix(std::move(_block_minimum_suffix)),
+                        sparse_table(std::move(_sp_state)) {}
+
+                internal_state(index_t _data_size,
+                               index_t _block_size,
+                               index_t _num_blocks,
+                               const container_t<index_t> &_block_minimum_prefix,
+                               const container_t<index_t> &_block_minimum_suffix,
+                               const sp_state_type &_sp_state) :
+                        data_size(_data_size),
+                        block_size(_block_size),
+                        num_blocks(_num_blocks),
+                        block_minimum_prefix(_block_minimum_prefix),
+                        block_minimum_suffix(_block_minimum_suffix),
+                        sparse_table(_sp_state) {}
+            };
+
+            auto get_state() const {
+                return internal_state<array_1d>(m_data_size,
+                        m_block_size,
+                        m_num_blocks,
+                        m_block_minimum_prefix,
+                        m_block_minimum_suffix,
+                        m_sparse_table.get_state());
+            }
+
+            template<template<typename> typename container_t, typename T>
+            static auto make_from_state(internal_state<container_t> &&state, const T &data) {
+                rmq_sparse_table_block<typename T::value_type> rmq;
+                rmq.template set_state(std::move(state), data);
+                return rmq;
+            }
+
+            template<template<typename> typename container_t, typename T>
+            static auto make_from_state(const internal_state<container_t> &state, const T &data) {
+                rmq_sparse_table_block<typename T::value_type> rmq;
+                rmq.template set_state(state, data);
+                return rmq;
+            }
+
+        private:
+
+            template<template<typename> typename container_t, typename T>
+            void set_state(internal_state<container_t> &&state, const T &data) {
+                m_data_size = state.data_size;
+                m_block_size = state.block_size;
+                m_num_blocks = state.num_blocks;
+                m_block_minimum_prefix = std::move(state.block_minimum_prefix);
+                m_block_minimum_suffix = std::move(state.block_minimum_suffix);
+                m_sparse_table = rmq_sparse_table<typename T::value_type>::make_from_state(
+                        std::move(state.sparse_table), data);
+                m_data = data.begin();
+            }
+
+            template<template<typename> typename container_t, typename T>
+            void set_state(const internal_state<container_t> &state, const T &data) {
+                m_data_size = state.data_size;
+                m_block_size = state.block_size;
+                m_num_blocks = state.num_blocks;
+                m_block_minimum_prefix = state.block_minimum_prefix;
+                m_block_minimum_suffix = state.block_minimum_suffix;
+                m_sparse_table = rmq_sparse_table<typename T::value_type>::make_from_state(state.sparse_table, data);
+                m_data = data.begin();
+            }
+
+            template<typename T>
+            void init(const T &values) {
+
+                /*
+                 * Blocks preprocessing
+                 */
+                array_1d<index_t> element_map = array_1d<index_t>::from_shape({(size_t) m_num_blocks});
+                parfor(0, m_num_blocks, [&element_map, this](index_t i) {
+                    index_t block_start = i * m_block_size;
+                    index_t block_end = std::min(block_start + m_block_size, m_data_size);
+
+                    // smallest element position in the i-th block
+                    element_map(i) = std::min_element(m_data + block_start, m_data + block_end) - m_data;
+
+                    // minimum prefix block
+                    index_t current_minimum_index = block_start;
+                    index_t current_minimum = m_data[current_minimum_index];
+
+                    m_block_minimum_prefix(block_start) = current_minimum_index;
+                    for (index_t j = block_start + 1; j < block_start + m_block_size; ++j) {
+                        if (j < block_end && m_data[j] < current_minimum) {
+                            current_minimum = m_data[j];
+                            current_minimum_index = j;
+                        }
+                        m_block_minimum_prefix(j) = current_minimum_index;
+                    }
+
+                    // minimum suffix block
+                    current_minimum_index = block_start + m_block_size - 1;
+                    current_minimum = (current_minimum_index < block_end) ? m_data[current_minimum_index] : -1;
+
+                    m_block_minimum_suffix(block_start + m_block_size - 1) = current_minimum_index;
+                    for (index_t j = block_start + m_block_size - 2; j >= block_start; --j) {
+                        if (j < block_end && m_data[j] < current_minimum) {
+                            current_minimum = m_data[j];
+                            current_minimum_index = j;
+                        }
+                        m_block_minimum_suffix(j) = current_minimum_index;
+                    }
+                });
+
+                m_sparse_table = rmq_sparse_table<index_t>(values, std::move(element_map));
+            }
+
+            const data_t *m_data;
+            index_t m_data_size;
+            index_t m_block_size;
+            index_t m_num_blocks;
+            array_1d <index_t> m_block_minimum_prefix;
+            array_1d <index_t> m_block_minimum_suffix;
+            rmq_sparse_table<index_t> m_sparse_table;
+
+        };
+    }
+}

--- a/include/higra/structure/details/range_minimum_query.hpp
+++ b/include/higra/structure/details/range_minimum_query.hpp
@@ -121,14 +121,14 @@ namespace hg {
             template<template<typename> typename container_t, typename T>
             static auto make_from_state(internal_state<container_t> &&state, const T &data) {
                 rmq_sparse_table<typename T::value_type> rmq;
-                rmq.template set_state(std::move(state), data);
+                rmq.set_state(std::move(state), data);
                 return rmq;
             }
 
             template<template<typename> typename container_t, typename T>
             static auto make_from_state(const internal_state<container_t> &state, const T &data) {
                 rmq_sparse_table<typename T::value_type> rmq;
-                rmq.template set_state(state, data);
+                rmq.set_state(state, data);
                 return rmq;
             }
 
@@ -232,7 +232,7 @@ namespace hg {
                 index_t rb = r / m_block_size;
                 if (lb != rb) { // speculative policy
                     index_t ret = m_sparse_table.query(lb, std::min(m_num_blocks, rb + 1));
-                    if (ret >= l and ret < r) return ret;
+                    if (ret >= l && ret < r) return ret;
                 } else {
                     if (m_block_minimum_prefix(r) >= l)
                         return m_block_minimum_prefix(r);
@@ -302,14 +302,14 @@ namespace hg {
             template<template<typename> typename container_t, typename T>
             static auto make_from_state(internal_state<container_t> &&state, const T &data) {
                 rmq_sparse_table_block<typename T::value_type> rmq;
-                rmq.template set_state(std::move(state), data);
+                rmq.set_state(std::move(state), data);
                 return rmq;
             }
 
             template<template<typename> typename container_t, typename T>
             static auto make_from_state(const internal_state<container_t> &state, const T &data) {
                 rmq_sparse_table_block<typename T::value_type> rmq;
-                rmq.template set_state(state, data);
+                rmq.set_state(state, data);
                 return rmq;
             }
 

--- a/include/higra/structure/embedding.hpp
+++ b/include/higra/structure/embedding.hpp
@@ -81,11 +81,12 @@ namespace hg {
              * @param shape list of dim positive integers
              */
             embedding_grid(const std::initializer_list<index_t> &shape) {
-                hg_assert(dim == _shape.size(), "Shape dimension does not match embedding dimension !");
+                hg_assert(dim == shape.size(), "Shape dimension does not match embedding dimension !");
                 _shape = xt::zeros<index_t>({shape.size()});
                 index_t i = 0;
-                for (const auto c:shape)
+                for (const auto c:shape){
                     _shape(i++) = c;
+                }
                 assert_positive_shape();
                 computeSumProd();
                 computeSize();

--- a/include/higra/structure/lca_fast.hpp
+++ b/include/higra/structure/lca_fast.hpp
@@ -157,7 +157,7 @@ namespace hg {
             static auto make_from_state(internal_state<container_t> &&state) {
                 using lca_t = typename internal_state<container_t>::type;
                 lca_t lca;
-                lca.template set_state(std::move(state));
+                lca.set_state(std::move(state));
                 return lca;
             }
 
@@ -165,7 +165,7 @@ namespace hg {
             static auto make_from_state(const internal_state<container_t> &state) {
                 using lca_t = typename internal_state<container_t>::type;
                 lca_t lca;
-                lca.template set_state(state);
+                lca.set_state(state);
                 return lca;
             }
 

--- a/include/higra/structure/lca_fast.hpp
+++ b/include/higra/structure/lca_fast.hpp
@@ -25,9 +25,17 @@ namespace hg {
         template<typename tree_t, typename rmq_t>
         struct lca_rmq {
 
+            using rmq_type = rmq_t;
+
         public:
             using self_type = lca_rmq<tree_t, rmq_t>;
 
+            /**
+             * Extra arguments are forwarded to the range minimum query solver constructor
+             * @tparam Args
+             * @param tree
+             * @param args
+             */
             template<typename ...Args>
             lca_rmq(const tree_t &tree, Args &&... args) {
                 HG_TRACE();
@@ -194,10 +202,6 @@ namespace hg {
 
             // rmq solver
             rmq_t m_rmq_solver;
-
-            static inline index_t fast_log2(size_t length) {
-                return sizeof(size_t) * 8 - 1 - __builtin_clzll(length);
-            }
 
             void compute_Euler_tour(const tree_t &tree) {
                 tree.compute_children();

--- a/include/higra/structure/regular_graph.hpp
+++ b/include/higra/structure/regular_graph.hpp
@@ -88,7 +88,7 @@ namespace hg {
 
             regular_graph(embedding_t _embedding = {}, point_list_t<index_t, embedding_t::_dim> _neighbours = {})
                     : m_embedding(_embedding), m_neighbours(_neighbours) {
-                init_safe_are();
+                init_safe_area();
             }
 
             ~regular_graph() = default;
@@ -105,11 +105,19 @@ namespace hg {
 
         private:
 
-            void init_safe_are() {
+            void init_safe_area() {
                 // determine the largest sub domain such that every neighbours of a vertex is present in the graph domain
                 // for a vertex in this domain, we can just use the relative linear index to find its neighbours
+                if (m_neighbours.size() == 0){
+                    m_safe_lower_bound.fill(std::numeric_limits<index_t>::lowest());
+                    m_safe_upper_bound.fill(std::numeric_limits<index_t>::max());
+                    return;
+                }
+
                 m_safe_lower_bound.fill(std::numeric_limits<index_t>::max());
                 m_safe_upper_bound.fill(std::numeric_limits<index_t>::lowest());
+
+
                 for (const auto &n: m_neighbours) {
                     m_safe_lower_bound = xt::minimum(m_safe_lower_bound, n);
                     m_safe_upper_bound = xt::maximum(m_safe_upper_bound, n);
@@ -198,7 +206,9 @@ namespace hg {
             void increment() {
                 if (safe_area) {
                     ++current_element;
-                    neighbour = source + graph.m_relative_neighbours[current_element];
+                    if (current_element != num_elem) {
+                        neighbour = source + graph.m_relative_neighbours[current_element];
+                    }
                 } else {
                     bool flag;
                     point_type neighbourc;
@@ -342,9 +352,9 @@ namespace hg {
         } else {
             degree_size_type count = 0;
             auto its = adjacent_vertices(v, *this);
-            auto & it1 = its.first;
-            auto & it2 = its.second;
-            for (;it1 != it2; ++it1) {
+            auto &it1 = its.first;
+            auto &it2 = its.second;
+            for (; it1 != it2; ++it1) {
                 count++;
             }
             return count;

--- a/include/higra/structure/regular_graph.hpp
+++ b/include/higra/structure/regular_graph.hpp
@@ -159,7 +159,7 @@ namespace hg {
             point<index_t, embedding_t::_dim> m_safe_upper_bound;
             std::vector<index_t> m_relative_neighbours;
 
-            friend class regular_graph_adjacent_vertex_iterator<embedding_t>;
+            friend struct regular_graph_adjacent_vertex_iterator<embedding_t>;
         };
 
         // Iterator

--- a/test/cpp/structure/test_lca.cpp
+++ b/test/cpp/structure/test_lca.cpp
@@ -9,9 +9,11 @@
 ****************************************************************************/
 
 #include "xtensor/xio.hpp"
+#include "xtensor/xrandom.hpp"
 #include "higra/graph.hpp"
 #include "higra/image/graph_image.hpp"
 #include "higra/structure/lca_fast.hpp"
+#include "higra/hierarchy/hierarchy_core.hpp"
 #include "../test_utils.hpp"
 
 namespace lca {
@@ -29,9 +31,9 @@ namespace lca {
     } data;
 
 
-    TEST_CASE("lca pairs of vertices", "[lca]") {
+    TEMPLATE_TEST_CASE("lca pairs of vertices", "[lca]", hg::lca_sparse_table, hg::lca_sparse_table_block) {
         auto t = data.t;
-        lca_fast lca(t);
+        TestType lca(t);
         REQUIRE(lca.lca(0, 0) == 0);
         REQUIRE(lca.lca(3, 3) == 3);
         REQUIRE(lca.lca(5, 5) == 5);
@@ -47,18 +49,18 @@ namespace lca {
         REQUIRE(lca.lca(2, 6) == 6);
     }
 
-    TEST_CASE("lca iterators", "[lca]") {
+    TEMPLATE_TEST_CASE("lca iterators", "[lca]", hg::lca_sparse_table, hg::lca_sparse_table_block) {
         auto g = get_4_adjacency_graph({2, 2});
         tree t(array_1d<index_t>{4, 4, 5, 5, 6, 6, 6});
-        lca_fast lca(t);
+        TestType lca(t);
         auto l = lca.lca(edge_iterator(g));
         array_1d<index_t> ref{4, 6, 6, 5};
         REQUIRE((l == ref));
     }
 
-    TEST_CASE("lca tensors", "[lca]") {
+    TEMPLATE_TEST_CASE("lca tensors", "[lca]", hg::lca_sparse_table, hg::lca_sparse_table_block) {
         tree t(array_1d<index_t>{4, 4, 5, 5, 6, 6, 6});
-        lca_fast lca(t);
+        TestType lca(t);
         array_1d<index_t> v1{0, 0, 1, 3};
         array_1d<index_t> v2{0, 3, 0, 0};
         auto l = lca.lca(v1, v2);
@@ -66,20 +68,58 @@ namespace lca {
         REQUIRE((l == ref));
     }
 
-    TEST_CASE("lca serialization", "[lca]") {
+    TEMPLATE_TEST_CASE("lca sanity", "[lca]", hg::lca_sparse_table, hg::lca_sparse_table_block) {
+        xt::random::seed(42);
+        auto g = hg::get_4_adjacency_graph({20, 20});
+        auto w = xt::random::rand<double>({num_edges(g)});
+        auto h = hg::bpt_canonical(g, w);
+        auto &tree = h.tree;
+
+        TestType lca(tree);
+        for (index_t i = 0; i < (index_t)num_vertices(g); ++i) {
+            for (index_t j = i; j < (index_t)num_vertices(g); j++) {
+                auto ref = lowest_common_ancestor(i, j, tree);
+                auto r1 = lca.lca(i, j);
+                auto r2 = lca.lca(j, i);
+                REQUIRE(ref == r1);
+                REQUIRE(ref == r2);
+            }
+        }
+    }
+
+    TEST_CASE("lca sparse table block", "[lca]") {
+        xt::random::seed(42);
+        auto g = hg::get_4_adjacency_graph({10, 10});
+        auto w = xt::random::rand<double>({num_edges(g)});
+        auto h = hg::bpt_canonical(g, w);
+        auto &tree = h.tree;
+
+        hg::lca_sparse_table_block lca(tree, 4);
+        for (index_t i = 0; i < (index_t)num_vertices(g); ++i) {
+            for (index_t j = i; j < (index_t)num_vertices(g); j++) {
+                auto ref = lowest_common_ancestor(i, j, tree);
+                auto r1 = lca.lca(i, j);
+                auto r2 = lca.lca(j, i);
+                REQUIRE(ref == r1);
+                REQUIRE(ref == r2);
+            }
+        }
+    }
+
+    TEMPLATE_TEST_CASE("lca serialization", "[lca]", hg::lca_sparse_table, hg::lca_sparse_table_block) {
         tree t(array_1d<index_t>{4, 4, 5, 5, 6, 6, 6});
-        lca_fast lca(t);
+        TestType lca(t);
         array_1d<index_t> v1{0, 0, 1, 3};
         array_1d<index_t> v2{0, 3, 0, 0};
 
         auto state = lca.get_state();
 
-        lca_fast lca2 = lca_fast::make_lca_fast(state);
+        TestType lca2 = TestType::make_from_state(state);
         array_1d<index_t> ref{0, 6, 4, 6};
         auto l = lca2.lca(v1, v2);
         REQUIRE((l == ref));
 
-        lca_fast lca3 =lca_fast::make_lca_fast(std::move(state));
+        TestType lca3 = TestType::make_from_state(std::move(state));
         auto l2 = lca3.lca(v1, v2);
         REQUIRE((l2 == ref));
     }

--- a/test/python/test_structure/test_lca_fast.py
+++ b/test/python/test_structure/test_lca_fast.py
@@ -22,7 +22,28 @@ class TestLCAFast(unittest.TestCase):
 
     def test_LCAFast(self):
         t = TestLCAFast.getTree()
-        lca = hg.LCAFast(t)
+        for lca_t in [hg.LCA_rmq_sparse_table, hg.LCA_rmq_sparse_table_block]:
+            with self.subTest(lca_type=lca_t):
+                lca = lca_t(t)
+
+                self.assertTrue(lca.lca(0, 0) == 0)
+                self.assertTrue(lca.lca(3, 3) == 3)
+                self.assertTrue(lca.lca(5, 5) == 5)
+                self.assertTrue(lca.lca(7, 7) == 7)
+                self.assertTrue(lca.lca(0, 1) == 5)
+                self.assertTrue(lca.lca(1, 0) == 5)
+                self.assertTrue(lca.lca(2, 3) == 6)
+                self.assertTrue(lca.lca(2, 4) == 6)
+                self.assertTrue(lca.lca(3, 4) == 6)
+                self.assertTrue(lca.lca(5, 6) == 7)
+                self.assertTrue(lca.lca(0, 2) == 7)
+                self.assertTrue(lca.lca(1, 4) == 7)
+                self.assertTrue(lca.lca(2, 6) == 6)
+
+    def test_LCA_sp_block_size(self):
+        t = TestLCAFast.getTree()
+
+        lca = hg.LCA_rmq_sparse_table_block(t, 2)
 
         self.assertTrue(lca.lca(0, 0) == 0)
         self.assertTrue(lca.lca(3, 3) == 3)
@@ -41,40 +62,48 @@ class TestLCAFast(unittest.TestCase):
     def test_LCAFastV(self):
         g = hg.get_4_adjacency_graph((2, 2))
         t = hg.Tree((4, 4, 5, 5, 6, 6, 6))
-        lca = hg.LCAFast(t)
+        for lca_t in [hg.LCA_rmq_sparse_table, hg.LCA_rmq_sparse_table_block]:
+            with self.subTest(lca_type=lca_t):
+                lca = lca_t(t)
 
-        ref = (4, 6, 6, 5)
-        res = lca.lca(g)
-        self.assertTrue(np.all(ref == res))
+                ref = (4, 6, 6, 5)
+                res = lca.lca(g)
+                self.assertTrue(np.all(ref == res))
 
     def test_LCAFastVertices(self):
         t = hg.Tree((4, 4, 5, 5, 6, 6, 6))
-        lca = hg.LCAFast(t)
-        res = lca.lca((0, 0, 1, 3), (0, 3, 0, 0))
-        self.assertTrue(np.all(res == (0, 6, 4, 6)))
+        for lca_t in [hg.LCA_rmq_sparse_table, hg.LCA_rmq_sparse_table_block]:
+            with self.subTest(lca_type=lca_t):
+                lca = lca_t(t)
+                res = lca.lca((0, 0, 1, 3), (0, 3, 0, 0))
+                self.assertTrue(np.all(res == (0, 6, 4, 6)))
 
     def test_dynamic_attributes(self):
         t = hg.Tree((4, 4, 5, 5, 6, 6, 6))
-        lca = hg.LCAFast(t)
-        lca.new_attribute = 42
-        self.assertTrue(lca.new_attribute == 42)
+        for lca_t in [hg.LCA_rmq_sparse_table, hg.LCA_rmq_sparse_table_block]:
+            with self.subTest(lca_type=lca_t):
+                lca = lca_t(t)
+                lca.new_attribute = 42
+                self.assertTrue(lca.new_attribute == 42)
 
     def test_pickle(self):
         import pickle
         tree = hg.Tree((4, 4, 5, 5, 6, 6, 6))
-        lca = hg.LCAFast(tree)
-        hg.set_attribute(lca, "test", (1, 2, 3))
-        hg.add_tag(lca, "foo")
+        for lca_t in [hg.LCA_rmq_sparse_table, hg.LCA_rmq_sparse_table_block]:
+            with self.subTest(lca_type=lca_t):
+                lca = lca_t(tree)
+                hg.set_attribute(lca, "test", (1, 2, 3))
+                hg.add_tag(lca, "foo")
 
-        data = pickle.dumps(lca)
-        lca2 = pickle.loads(data)
+                data = pickle.dumps(lca)
+                lca2 = pickle.loads(data)
 
-        res = lca2.lca((0, 0, 1, 3), (0, 3, 0, 0))
-        self.assertTrue(np.all(res == (0, 6, 4, 6)))
+                res = lca2.lca((0, 0, 1, 3), (0, 3, 0, 0))
+                self.assertTrue(np.all(res == (0, 6, 4, 6)))
 
-        self.assertTrue(hg.get_attribute(lca, "test") == hg.get_attribute(lca2, "test"))
-        self.assertTrue(lca.test == lca2.test)
-        self.assertTrue(hg.has_tag(lca2, "foo"))
+                self.assertTrue(hg.get_attribute(lca, "test") == hg.get_attribute(lca2, "test"))
+                self.assertTrue(lca.test == lca2.test)
+                self.assertTrue(hg.has_tag(lca2, "foo"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactor fast LCA computation based on range minimum query and add a new algorithm based on block decomposition with an expected speedup comprised between 1.2 and 1.8 (tested on graphs with 100,000 to 10,000,000 edges)

Thanks to @lnajman for the POC and initial benchmark