### PR TITLE
Add contrast attribute to tree attributes

### DIFF
--- a/doc/source/python/tree_attributes.rst
+++ b/doc/source/python/tree_attributes.rst
@@ -12,6 +12,7 @@ Tree attributes
     attribute_contour_length
     attribute_contour_strength
     attribute_compactness
+    attribute_contrast
     attribute_depth
     attribute_dynamics
     attribute_extinction_value
@@ -40,6 +41,8 @@ Tree attributes
 .. autofunction:: higra.attribute_contour_strength
 
 .. autofunction:: higra.attribute_compactness
+
+.. autofunction:: higra.attribute_contrast
 
 .. autofunction:: higra.attribute_depth
 

--- a/doc/source/python/tree_attributes.rst
+++ b/doc/source/python/tree_attributes.rst
@@ -12,7 +12,6 @@ Tree attributes
     attribute_contour_length
     attribute_contour_strength
     attribute_compactness
-    attribute_contrast
     attribute_depth
     attribute_dynamics
     attribute_extinction_value
@@ -41,8 +40,6 @@ Tree attributes
 .. autofunction:: higra.attribute_contour_strength
 
 .. autofunction:: higra.attribute_compactness
-
-.. autofunction:: higra.attribute_contrast
 
 .. autofunction:: higra.attribute_depth
 

--- a/higra/attribute/tree_attributes.py
+++ b/higra/attribute/tree_attributes.py
@@ -747,3 +747,22 @@ def attribute_moment_of_inertia(tree, leaf_graph):
     I_1 = (miu_20 + miu_02) / (M_00 ** 2)
 
     return I_1
+
+
+@hg.auto_cache
+def attribute_contrast(tree, altitudes):
+    """
+    Given a node :math:`n` of the tree :math:`T`, the contrast of :math:`n` is the difference between
+    the altitude of the deepest minima of the subtree rooted in :math:`n` and the altitude of :math:`n`.
+
+    :param tree: Input tree
+    :param altitudes: Tree node altitudes
+    :return: a 1d array like :attr:`altitudes`
+    """
+
+    res = hg.accumulate_sequential(tree,
+                                   altitudes[:tree.num_leaves()],
+                                   hg.Accumulators.max)
+    res -= altitudes
+
+    return res

--- a/higra/attribute/tree_attributes.py
+++ b/higra/attribute/tree_attributes.py
@@ -489,8 +489,9 @@ def attribute_extinction_value(tree, altitudes, attribute, increasing_altitudes=
 def attribute_height(tree, altitudes, increasing_altitudes="auto", reference_altitude="parent"):
     """
     In a tree :math:`T`, given that the altitudes of the nodes vary monotically from the leaves to the root,
-    the height of a node :math:`n` of :math:`T` is equal to the difference between the altitude of the parent
-    of :math:`n` and the altitude of the deepest non-leaf node in the subtree of :math:`T` rooted in :math:`n`.
+    the height of a node :math:n of :math:T is equal to the difference between the altitude of the reference
+    node (either :math:n or the parent of :math:n) and the altitude of the deepest non-leaf node in the subtree
+    of :math:T rooted in :math:n.
 
     Possible values of :attr:`increasing_altitude` are:
 
@@ -503,10 +504,8 @@ def attribute_height(tree, altitudes, increasing_altitudes="auto", reference_alt
 
     Possible values of :attr:`reference_altitude` are:
 
-        - ``'parent'``: the function will compute the height attribute.
-        - ```'current'``: the function will compute the contrast attribute.
-          (ie. the difference between the altitude of the current node and the altitude of the
-          deepest non-leaf node in the subtree of :math:`T` rooted in :math:`n`).
+        - ``'parent'``: the reference altitude is the altitude of the parent of the current node.
+        - ``'current'``: the reference altitude is the altitude of the current node.
 
     :param tree: Input tree
     :param altitudes: Tree node altitudes

--- a/higra/attribute/tree_attributes.py
+++ b/higra/attribute/tree_attributes.py
@@ -486,7 +486,7 @@ def attribute_extinction_value(tree, altitudes, attribute, increasing_altitudes=
 
 
 @hg.auto_cache
-def attribute_height(tree, altitudes, increasing_altitudes="auto"):
+def attribute_height(tree, altitudes, increasing_altitudes="auto", reference_altitude="parent"):
     """
     In a tree :math:`T`, given that the altitudes of the nodes vary monotically from the leaves to the root,
     the height of a node :math:`n` of :math:`T` is equal to the difference between the altitude of the parent
@@ -501,14 +501,34 @@ def attribute_height(tree, altitudes, increasing_altitudes="auto"):
         - ``False`` or ``'decreasing'``: this means that altitudes are decreasing from the leaves to the root
           (ie. for any node :math:`n`, :math:`altitude(n) \geq altitude(parent(n))`.
 
+    Possible values of :attr:`reference_altitude` are:
+
+        - ``'parent'``: the function will compute the height attribute.
+        - ```'current'``: the function will compute the contrast attribute.
+          (ie. the difference between the altitude of the current node and the altitude of the
+          deepest non-leaf node in the subtree of :math:`T` rooted in :math:`n`).
+
     :param tree: Input tree
     :param altitudes: Tree node altitudes
     :param increasing_altitudes: possible values 'auto', True, False, 'increasing', and 'decreasing'
+    :param reference_altitude: possible values 'parent' and 'current'
     :return: a 1d array like :attr:`altitudes`
     """
     inc = __process_param_increasing_altitudes(tree, altitudes, increasing_altitudes)
 
-    res = hg.cpp._attribute_height(tree, altitudes, inc)
+    if reference_altitude == "current":
+        if inc:
+            res = hg.accumulate_sequential(tree,
+                                           altitudes[:tree.num_leaves()],
+                                           hg.Accumulators.max)\
+                  - altitudes
+        else:
+            res = altitudes -\
+                  hg.accumulate_sequential(tree,
+                                           altitudes[:tree.num_leaves()],
+                                           hg.Accumulators.min)
+    else:
+        res = hg.cpp._attribute_height(tree, altitudes, inc)
 
     return res
 
@@ -709,9 +729,9 @@ def attribute_moment_of_inertia(tree, leaf_graph):
     .. math::
 
         I_1 = \eta_{20} + \eta_{02}
-        
+
     where :math:`\eta_{ij}` are given by:
-    
+
         :math:`\eta_{ij} = \\frac{\mu_{ij}}{\mu_{00}^{1+\\frac{i+j}{2}}}`
 
     :param tree: input tree (Concept :class:`~higra.CptHierarchy`)
@@ -747,22 +767,3 @@ def attribute_moment_of_inertia(tree, leaf_graph):
     I_1 = (miu_20 + miu_02) / (M_00 ** 2)
 
     return I_1
-
-
-@hg.auto_cache
-def attribute_contrast(tree, altitudes):
-    """
-    Given a node :math:`n` of the tree :math:`T`, the contrast of :math:`n` is the difference between
-    the altitude of the deepest minima of the subtree rooted in :math:`n` and the altitude of :math:`n`.
-
-    :param tree: Input tree
-    :param altitudes: Tree node altitudes
-    :return: a 1d array like :attr:`altitudes`
-    """
-
-    res = hg.accumulate_sequential(tree,
-                                   altitudes[:tree.num_leaves()],
-                                   hg.Accumulators.max)
-    res -= altitudes
-
-    return res

--- a/test/python/test_attribute/test_attributes.py
+++ b/test/python/test_attribute/test_attributes.py
@@ -668,5 +668,35 @@ class TestAttributes(unittest.TestCase):
                0.1481, 0.2222, 0.16, 0.2222, 0.2756)
         self.assertTrue(np.allclose(res,ref,atol=0.0001))
 
+    def test_contrast(self):
+        graph = hg.get_4_adjacency_implicit_graph((10, 10))
+        vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
+                                   [0, 2, 3, 3, 2, 1, 2, 2, 0, 0],
+                                   [0, 2, 4, 3, 2, 1, 0, 1, 0, 0],
+                                   [0, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 3, 0, 4, 2, 0, 0],
+                                   [0, 1, 1, 0, 3, 2, 4, 4, 0, 0],
+                                   [0, 1, 1, 0, 3, 0, 4, 4, 1, 0],
+                                   [0, 1, 1, 0, 0, 0, 0, 1, 1, 0],
+                                   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        ref_map = np.array([[4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 0, 1, 0, 4, 4, 4, 0, 0, 4],
+                            [4, 2, 1, 1, 2, 3, 0, 0, 4, 4],
+                            [4, 2, 0, 1, 2, 3, 4, 3, 4, 4],
+                            [4, 4, 2, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 4, 4, 4, 0, 4, 0, 2, 4, 4],
+                            [4, 0, 0, 4, 0, 2, 0, 0, 4, 4],
+                            [4, 0, 0, 4, 0, 4, 0, 0, 3, 4],
+                            [4, 0, 0, 4, 4, 4, 4, 3, 3, 4],
+                            [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
+
+        tree, altitudes = hg.component_tree_max_tree(graph, vertex_weights)
+        contrast = hg.attribute_contrast(tree, altitudes)
+        map = hg.reconstruct_leaf_data(tree, contrast)
+
+        self.assertTrue(np.allclose(ref_map, map))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_attribute/test_attributes.py
+++ b/test/python/test_attribute/test_attributes.py
@@ -557,7 +557,7 @@ class TestAttributes(unittest.TestCase):
         res = hg.attribute_height(t, altitudes, "decreasing")
         self.assertTrue(np.all(res == ref))
 
-    def test_attribute_height_contrast_inc(self):
+    def test_attribute_height_current_inc(self):
         graph = hg.get_4_adjacency_implicit_graph((10, 10))
         vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                    [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
@@ -581,12 +581,12 @@ class TestAttributes(unittest.TestCase):
                             [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
 
         tree, altitudes = hg.component_tree_max_tree(graph, vertex_weights)
-        contrast = hg.attribute_height(tree, altitudes, True, "current")
-        map = hg.reconstruct_leaf_data(tree, contrast)
+        height = hg.attribute_height(tree, altitudes, True, "current")
+        map = hg.reconstruct_leaf_data(tree, height)
 
         self.assertTrue(np.allclose(ref_map, map))
 
-    def test_attribute_height_contrast_dec(self):
+    def test_attribute_height_current_dec(self):
         graph = hg.get_4_adjacency_implicit_graph((10, 10))
         vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                    [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
@@ -610,8 +610,8 @@ class TestAttributes(unittest.TestCase):
                             [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
 
         tree, altitudes = hg.component_tree_min_tree(graph, vertex_weights.max()-vertex_weights)
-        contrast = hg.attribute_height(tree, altitudes, False, "current")
-        map = hg.reconstruct_leaf_data(tree, contrast)
+        height = hg.attribute_height(tree, altitudes, False, "current")
+        map = hg.reconstruct_leaf_data(tree, height)
 
         self.assertTrue(np.allclose(ref_map, map))
 

--- a/test/python/test_attribute/test_attributes.py
+++ b/test/python/test_attribute/test_attributes.py
@@ -557,6 +557,64 @@ class TestAttributes(unittest.TestCase):
         res = hg.attribute_height(t, altitudes, "decreasing")
         self.assertTrue(np.all(res == ref))
 
+    def test_attribute_height_contrast_inc(self):
+        graph = hg.get_4_adjacency_implicit_graph((10, 10))
+        vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
+                                   [0, 2, 3, 3, 2, 1, 2, 2, 0, 0],
+                                   [0, 2, 4, 3, 2, 1, 0, 1, 0, 0],
+                                   [0, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 3, 0, 4, 2, 0, 0],
+                                   [0, 1, 1, 0, 3, 2, 4, 4, 0, 0],
+                                   [0, 1, 1, 0, 3, 0, 4, 4, 1, 0],
+                                   [0, 1, 1, 0, 0, 0, 0, 1, 1, 0],
+                                   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        ref_map = np.array([[4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 0, 1, 0, 4, 4, 4, 0, 0, 4],
+                            [4, 2, 1, 1, 2, 3, 0, 0, 4, 4],
+                            [4, 2, 0, 1, 2, 3, 4, 3, 4, 4],
+                            [4, 4, 2, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 4, 4, 4, 0, 4, 0, 2, 4, 4],
+                            [4, 0, 0, 4, 0, 2, 0, 0, 4, 4],
+                            [4, 0, 0, 4, 0, 4, 0, 0, 3, 4],
+                            [4, 0, 0, 4, 4, 4, 4, 3, 3, 4],
+                            [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
+
+        tree, altitudes = hg.component_tree_max_tree(graph, vertex_weights)
+        contrast = hg.attribute_height(tree, altitudes, True, "current")
+        map = hg.reconstruct_leaf_data(tree, contrast)
+
+        self.assertTrue(np.allclose(ref_map, map))
+
+    def test_attribute_height_contrast_dec(self):
+        graph = hg.get_4_adjacency_implicit_graph((10, 10))
+        vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
+                                   [0, 2, 3, 3, 2, 1, 2, 2, 0, 0],
+                                   [0, 2, 4, 3, 2, 1, 0, 1, 0, 0],
+                                   [0, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 3, 0, 4, 2, 0, 0],
+                                   [0, 1, 1, 0, 3, 2, 4, 4, 0, 0],
+                                   [0, 1, 1, 0, 3, 0, 4, 4, 1, 0],
+                                   [0, 1, 1, 0, 0, 0, 0, 1, 1, 0],
+                                   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        ref_map = np.array([[4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 0, 1, 0, 4, 4, 4, 0, 0, 4],
+                            [4, 2, 1, 1, 2, 3, 0, 0, 4, 4],
+                            [4, 2, 0, 1, 2, 3, 4, 3, 4, 4],
+                            [4, 4, 2, 4, 4, 4, 4, 4, 4, 4],
+                            [4, 4, 4, 4, 0, 4, 0, 2, 4, 4],
+                            [4, 0, 0, 4, 0, 2, 0, 0, 4, 4],
+                            [4, 0, 0, 4, 0, 4, 0, 0, 3, 4],
+                            [4, 0, 0, 4, 4, 4, 4, 3, 3, 4],
+                            [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
+
+        tree, altitudes = hg.component_tree_min_tree(graph, vertex_weights.max()-vertex_weights)
+        contrast = hg.attribute_height(tree, altitudes, False, "current")
+        map = hg.reconstruct_leaf_data(tree, contrast)
+
+        self.assertTrue(np.allclose(ref_map, map))
+
     def test_attribute_dynamics(self):
         t = hg.Tree((8, 8, 9, 7, 7, 11, 11, 9, 10, 10, 12, 12, 12))
         altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 4, 8, 10.))
@@ -667,35 +725,6 @@ class TestAttributes(unittest.TestCase):
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0.1481, 0.2222, 0.16, 0.2222, 0.2756)
         self.assertTrue(np.allclose(res,ref,atol=0.0001))
-
-    def test_contrast(self):
-        graph = hg.get_4_adjacency_implicit_graph((10, 10))
-        vertex_weights = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 4, 3, 4, 0, 0, 0, 2, 2, 0],
-                                   [0, 2, 3, 3, 2, 1, 2, 2, 0, 0],
-                                   [0, 2, 4, 3, 2, 1, 0, 1, 0, 0],
-                                   [0, 0, 2, 0, 0, 0, 0, 0, 0, 0],
-                                   [0, 0, 0, 0, 3, 0, 4, 2, 0, 0],
-                                   [0, 1, 1, 0, 3, 2, 4, 4, 0, 0],
-                                   [0, 1, 1, 0, 3, 0, 4, 4, 1, 0],
-                                   [0, 1, 1, 0, 0, 0, 0, 1, 1, 0],
-                                   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
-        ref_map = np.array([[4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
-                            [4, 0, 1, 0, 4, 4, 4, 0, 0, 4],
-                            [4, 2, 1, 1, 2, 3, 0, 0, 4, 4],
-                            [4, 2, 0, 1, 2, 3, 4, 3, 4, 4],
-                            [4, 4, 2, 4, 4, 4, 4, 4, 4, 4],
-                            [4, 4, 4, 4, 0, 4, 0, 2, 4, 4],
-                            [4, 0, 0, 4, 0, 2, 0, 0, 4, 4],
-                            [4, 0, 0, 4, 0, 4, 0, 0, 3, 4],
-                            [4, 0, 0, 4, 4, 4, 4, 3, 3, 4],
-                            [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]], dtype=np.uint8)
-
-        tree, altitudes = hg.component_tree_max_tree(graph, vertex_weights)
-        contrast = hg.attribute_contrast(tree, altitudes)
-        map = hg.reconstruct_leaf_data(tree, contrast)
-
-        self.assertTrue(np.allclose(ref_map, map))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Creation of `attribute_contrast` in `tree_attribute` with doc and tests.

I did not setup full CI/CD on my side, so I did not run full test and build, only tested `test_attributes.py`.
