### PR TITLE
Start internal support for dynamic component-tree algorithms

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -62,15 +62,14 @@ endif ()
 
 find_package(benchmark REQUIRED)
 
-
 include_directories(${PROJECT_SOURCE_DIR}/lib/include ${PROJECT_SOURCE_DIR}/include ${TBB_INCLUDE_DIRS})
-
 include_directories(${GBENCHMARK_INCLUDE_DIRS})
 
 set(FILES_BENCHMARK
         main.cpp
         utils.cpp
         benchmark_lca.cpp
+        #        benchmark_component_tree_casf.cpp
         #benchmark_undirected_graph.cpp
         #benchmark_regular_graph.cpp
         #benchmark_accumulator.cpp
@@ -85,7 +84,6 @@ set(BENCHMARK_TARGET benchmark_higra)
 add_executable(${BENCHMARK_TARGET} ${FILES_BENCHMARK})
 target_compile_definitions(${BENCHMARK_TARGET} PRIVATE HG_USE_TBB)
 target_link_libraries(${BENCHMARK_TARGET} benchmark -lpthread ${TBB_LIBRARIES})
-
 
 
 add_custom_target(benchmark_exe

--- a/benchmark/benchmark_component_tree_casf.cpp
+++ b/benchmark/benchmark_component_tree_casf.cpp
@@ -1,0 +1,657 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "higra/algo/tree.hpp"
+#include "higra/attribute/tree_attribute.hpp"
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/hierarchy/component_tree_casf.hpp"
+#include "higra/image/graph_image.hpp"
+
+using namespace hg;
+
+namespace {
+
+/*
+ * CASF benchmark overview
+ * -----------------------
+ *
+ * This benchmark compares the CASF implementation with the naive alternating
+ * max-tree/min-tree-by-area reference on synthetic grayscale images.
+ *
+ * Default synthetic mode
+ * - One benchmark case corresponds to one generated grayscale image, identified
+ *   by model, resolution, threshold count, and seed index.
+ * - natural_like combines multi-scale value noise, broad illumination, and
+ *   soft ridge-like structures to produce irregular natural-looking variation.
+ * - piecewise_scene combines smooth backgrounds, soft geometric objects, and
+ *   weak local texture to produce piecewise-smooth scene-like content.
+ * - Current default profile: 10 seeds per model, 640x480, 1 repetition,
+ *   0 warmup, threshold counts {2, 4, 8, 16, 32}.
+ *
+ * Threshold schedule
+ * - The fixed threshold sequence is:
+ *   10 30 40 59 69 89 99 119 138 148 168 178 198 217 227 247
+ *   257 277 286 306 326 336 356 365 385 405 415 435 444 464 474 494
+ * - If a case requests n thresholds, the benchmark uses the first n values of
+ *   this sequence exactly.
+ *
+ * Validation
+ * - Every case validates the CASF output against the naive reference before
+ *   entering the measured loop.
+ * - speedup_vs_naive > 1 means CASF is faster than the naive baseline.
+ *
+ * How to run
+ * - CASF plus naive reference:
+ *   ./build-benchmark/benchmark/benchmark_higra \
+ *     --benchmark_filter='BM_component_tree_casf_.*' \
+ *     --benchmark_counters_tabular=true
+ * 
+ * - CASF only:
+ *   ./build-benchmark/benchmark/benchmark_higra \
+ *     --benchmark_filter='BM_component_tree_casf_area/.*' \
+ *     --benchmark_counters_tabular=true
+ *
+ * Representative results on Apple Silicon (640x480, 10 seeds, 1 repetition)
+ * - natural_like:
+ *   thresholds=2  -> about 58-69 ms, speedup about 1.50-1.73
+ *   thresholds=4  -> about 61-72 ms, speedup about 2.78-3.18
+ *   thresholds=8  -> about 64-74 ms, speedup about 5.29-6.07
+ *   thresholds=16 -> about 70-78 ms, speedup about 9.95-11.30
+ *   thresholds=32 -> about 78-84 ms, speedup about 15.94-20.16
+ * - piecewise_scene:
+ *   thresholds=2  -> about 44-48 ms, speedup about 1.89-1.96
+ *   thresholds=4  -> about 45-48 ms, speedup about 3.32-3.87
+ *   thresholds=8  -> about 45-51 ms, speedup about 7.21-8.00
+ *   thresholds=16 -> about 45-48 ms, speedup about 14.20-15.29
+ *   thresholds=32 -> about 46-50 ms, speedup about 28.29-31.45
+ *
+ */
+
+
+enum class BenchmarkImageModel {
+    natural_like,
+    piecewise_scene
+};
+
+constexpr std::array<uint32_t, 10> kBenchmarkSeeds = {
+        0x13579u,
+        0x24680u,
+        0x35791u,
+        0x46802u,
+        0x57913u,
+        0x68A24u,
+        0x79B35u,
+        0x8AC46u,
+        0x9BD57u,
+        0xACE68u
+};
+constexpr int kBenchmarkRepetitions = 1;
+constexpr double kBenchmarkWarmupSeconds = 0.0;
+constexpr int64_t kBenchmarkNumCols = 640;
+constexpr int64_t kBenchmarkNumRows = 480;
+
+const char *benchmark_image_model_name(BenchmarkImageModel model) {
+    switch (model) {
+        case BenchmarkImageModel::natural_like:
+            return "natural_like";
+        case BenchmarkImageModel::piecewise_scene:
+            return "piecewise_scene";
+    }
+    return "unknown";
+}
+
+// Builds the common textual prefix used in synthetic benchmark labels.
+std::string benchmark_case_label(BenchmarkImageModel model, int numThresholds) {
+    return std::string(benchmark_image_model_name(model))
+           + ", thresholds=" + std::to_string(numThresholds)
+           + ", seeds=" + std::to_string(kBenchmarkSeeds.size());
+}
+
+// Converts a floating-point intensity to uint8 with saturation.
+uint8_t clamp_to_u8(double value) {
+    return (uint8_t) std::clamp<int>((int) std::lround(value), 0, 255);
+}
+
+// Small deterministic hash used as the base pseudo-random source for procedural textures.
+double benchmark_hash01(uint32_t y, uint32_t x, uint32_t seed) {
+    uint32_t h = seed;
+    h ^= y + 0x9e3779b9u + (h << 6) + (h >> 2);
+    h ^= x + 0x9e3779b9u + (h << 6) + (h >> 2);
+    h *= 0x85ebca6bu;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35u;
+    h ^= h >> 16;
+    return (double) (h & 0x00ffffffu) / (double) 0x01000000u;
+}
+
+// Bilinearly interpolated value noise at a given scale.
+double benchmark_value_noise(double y, double x, double scale, uint32_t seed) {
+    const auto smoothstep01 = [](double t) {
+        return t * t * (3.0 - 2.0 * t);
+    };
+    const double ys = y / scale;
+    const double xs = x / scale;
+    const auto y0 = (uint32_t) std::floor(ys);
+    const auto x0 = (uint32_t) std::floor(xs);
+    const auto y1 = y0 + 1u;
+    const auto x1 = x0 + 1u;
+    const double fy = smoothstep01(ys - std::floor(ys));
+    const double fx = smoothstep01(xs - std::floor(xs));
+
+    const double v00 = benchmark_hash01(y0, x0, seed);
+    const double v01 = benchmark_hash01(y0, x1, seed);
+    const double v10 = benchmark_hash01(y1, x0, seed);
+    const double v11 = benchmark_hash01(y1, x1, seed);
+
+    const double vx0 = v00 + fx * (v01 - v00);
+    const double vx1 = v10 + fx * (v11 - v10);
+    return vx0 + fy * (vx1 - vx0);
+}
+
+// Four-octave fractional Brownian motion used to produce natural-looking low-frequency structure.
+double benchmark_fbm(double y, double x,
+                     const std::array<double, 4> &scales,
+                     const std::array<uint32_t, 4> &seeds) {
+    double sum = 0.0;
+    double amplitude = 1.0;
+    double norm = 0.0;
+    for (std::size_t i = 0; i < scales.size(); ++i) {
+        sum += amplitude * benchmark_value_noise(y, x, scales[i], seeds[i]);
+        norm += amplitude;
+        amplitude *= 0.5;
+    }
+    return sum / norm;
+}
+
+// Generic smoothstep between two edges, reused by soft geometric masks.
+double benchmark_smoothstep(double edge0, double edge1, double x) {
+    const double t = std::clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+}
+
+// Soft disk indicator with feathered boundary.
+double benchmark_soft_disk(double x, double y, double cx, double cy, double radius, double feather) {
+    const double d = std::sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
+    return 1.0 - benchmark_smoothstep(radius - feather, radius + feather, d);
+}
+
+// Soft ellipse indicator with feathered boundary.
+double benchmark_soft_ellipse(double x, double y, double cx, double cy, double rx, double ry, double feather) {
+    const double dx = (x - cx) / rx;
+    const double dy = (y - cy) / ry;
+    const double d = std::sqrt(dx * dx + dy * dy);
+    const double normalizedFeather = feather / std::max(rx, ry);
+    return 1.0 - benchmark_smoothstep(1.0 - normalizedFeather, 1.0 + normalizedFeather, d);
+}
+
+// Soft axis-aligned rectangle indicator with feathered boundary.
+double benchmark_soft_rect(double x, double y, double x0, double y0, double x1, double y1, double feather) {
+    const double left = benchmark_smoothstep(x0 - feather, x0 + feather, x);
+    const double right = 1.0 - benchmark_smoothstep(x1 - feather, x1 + feather, x);
+    const double top = benchmark_smoothstep(y0 - feather, y0 + feather, y);
+    const double bottom = 1.0 - benchmark_smoothstep(y1 - feather, y1 + feather, y);
+    return left * right * top * bottom;
+}
+
+// Natural-like synthetic pattern: irregular smooth texture, broad illumination, and soft ridges.
+array_1d<uint8_t> make_natural_like_benchmark_image(index_t numRows, index_t numCols, uint32_t seed) {
+    const index_t numPixels = numRows * numCols;
+    auto image = array_1d<uint8_t>::from_shape({(size_t) numPixels});
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<double> unit01(0.0, 1.0);
+    std::uniform_real_distribution<double> ampJitter(0.8, 1.25);
+    std::uniform_real_distribution<double> freqJitter(0.75, 1.35);
+    std::uniform_real_distribution<double> angleJitter(-M_PI, M_PI);
+    std::uniform_real_distribution<double> offsetJitter(-0.18, 0.18);
+
+    const int backgroundFamily = (int) (rng() % 3u);
+    const int ridgeCount = 2 + (int) (rng() % 3u);
+    const std::array<double, 4> fbmScales = {
+            36.0 * freqJitter(rng),
+            18.0 * freqJitter(rng),
+            9.0 * freqJitter(rng),
+            4.5 * freqJitter(rng)};
+    const std::array<uint32_t, 4> fbmSeeds = {
+            seed + 0x12345u, seed + 0x23456u, seed + 0x34567u, seed + 0x45678u};
+    const double phase1 = 2.0 * M_PI * unit01(rng);
+    const double phase2 = 2.0 * M_PI * unit01(rng);
+    const double phase3 = 2.0 * M_PI * unit01(rng);
+    const double phase4 = 2.0 * M_PI * unit01(rng);
+    const double edgeBias = 2.0 * unit01(rng) - 1.0;
+    const double textureLargeAmplitude = 96.0 * ampJitter(rng);
+    const double textureSmallScale = 4.0 * freqJitter(rng);
+    const double orientedFreqX1 = 0.020 + 0.030 * unit01(rng);
+    const double orientedFreqY1 = 0.025 + 0.040 * unit01(rng);
+    const double orientedFreqX2 = 0.018 + 0.035 * unit01(rng);
+    const double orientedFreqY2 = 0.016 + 0.028 * unit01(rng);
+    const double dir1 = angleJitter(rng);
+    const double dir2 = angleJitter(rng);
+    const double ux1 = std::cos(dir1);
+    const double uy1 = std::sin(dir1);
+    const double ux2 = std::cos(dir2);
+    const double uy2 = std::sin(dir2);
+    const double centerX = 0.45 + offsetJitter(rng);
+    const double centerY = 0.52 + offsetJitter(rng);
+    const double notchDx = 0.18 + 0.12 * unit01(rng);
+    const double notchDy = -0.24 + 0.16 * unit01(rng);
+    std::vector<std::array<double, 5>> ridges;
+    ridges.reserve((size_t) ridgeCount);
+    for (int i = 0; i < ridgeCount; ++i) {
+        ridges.push_back({
+                unit01(rng),
+                unit01(rng),
+                0.10 + 0.18 * unit01(rng),
+                0.04 + 0.08 * unit01(rng),
+                (unit01(rng) < 0.5 ? -1.0 : 1.0) * (18.0 + 24.0 * unit01(rng))
+        });
+    }
+
+    for (index_t r = 0; r < numRows; ++r) {
+        for (index_t c = 0; c < numCols; ++c) {
+            const index_t p = r * numCols + c;
+            const double y = (double) r;
+            const double x = (double) c;
+            const double xn = x / (double) std::max<index_t>(1, numCols - 1);
+            const double yn = y / (double) std::max<index_t>(1, numRows - 1);
+            const double coord1 = ux1 * xn + uy1 * yn;
+            const double coord2 = ux2 * xn + uy2 * yn;
+
+            double illumination = 70.0;
+            if (backgroundFamily == 0) {
+                illumination += 42.0 * coord1 + 26.0 * coord2;
+            } else if (backgroundFamily == 1) {
+                illumination += 30.0 * std::sin(4.8 * coord1 + phase1) + 24.0 * std::cos(3.7 * coord2 + phase2);
+            } else {
+                const double dx = xn - centerX;
+                const double dy = yn - centerY;
+                illumination += 110.0 * std::exp(-(dx * dx / 0.22 + dy * dy / 0.15));
+                illumination -= 36.0 * std::exp(-((dx - notchDx) * (dx - notchDx) / 0.08 + (dy - notchDy) * (dy - notchDy) / 0.05));
+            }
+
+            const double textureLarge = textureLargeAmplitude * benchmark_fbm(0.85 * y, 0.85 * x, fbmScales, fbmSeeds);
+            const double textureSmall = 18.0 * benchmark_value_noise(y, x, textureSmallScale, seed + 0x56789u);
+            const double oriented =
+                    12.0 * std::sin(orientedFreqX1 * x + orientedFreqY1 * y + phase3)
+                    + 9.0 * std::cos(orientedFreqX2 * x - orientedFreqY2 * y + phase4);
+
+            const double edgeLike =
+                    benchmark_value_noise(y, x, 19.0, seed + 0x6789Au) > 0.5 ? (9.0 + 3.0 * edgeBias) : (-9.0 - 3.0 * edgeBias);
+
+            double ridgeContribution = 0.0;
+            for (const auto &ridge: ridges) {
+                const double cx = ridge[0] * (double) numCols;
+                const double cy = ridge[1] * (double) numRows;
+                const double rx = ridge[2] * (double) numCols;
+                const double ry = ridge[3] * (double) numRows;
+                ridgeContribution += ridge[4] * benchmark_soft_ellipse(x, y, cx, cy, rx, ry, 6.0);
+            }
+
+            image(p) = clamp_to_u8(illumination + textureLarge + textureSmall + oriented + edgeLike + ridgeContribution - 55.0);
+        }
+    }
+    return image;
+}
+
+// Piecewise-scene synthetic pattern: smooth background plus soft geometric objects and weak texture.
+array_1d<uint8_t> make_piecewise_scene_benchmark_image(index_t numRows, index_t numCols, uint32_t seed) {
+    const index_t numPixels = numRows * numCols;
+    auto image = array_1d<uint8_t>::from_shape({(size_t) numPixels});
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<double> unit01(0.0, 1.0);
+    const std::array<double, 4> backgroundScales = {96.0, 48.0, 24.0, 12.0};
+    const std::array<uint32_t, 4> backgroundSeeds = {
+            seed + 0x13579u, seed + 0x24680u, seed + 0x35791u, seed + 0x46802u};
+    const std::array<double, 4> objectScales = {40.0, 20.0, 10.0, 5.0};
+    const std::array<uint32_t, 4> objectSeeds = {
+            seed + 0x51051u, seed + 0x62062u, seed + 0x73073u, seed + 0x84084u};
+    const int backgroundFamily = (int) (rng() % 3u);
+    const int objectCount = 4 + (int) (rng() % 4u);
+    struct ObjectSpec {
+        int type;
+        double cx;
+        double cy;
+        double sx;
+        double sy;
+        double feather;
+        double contrast;
+        double phase;
+    };
+    std::vector<ObjectSpec> objects;
+    objects.reserve((size_t) objectCount);
+    for (int i = 0; i < objectCount; ++i) {
+        const int type = (int) (rng() % 5u);
+        const double cx = (0.12 + 0.76 * unit01(rng)) * (double) numCols;
+        const double cy = (0.12 + 0.76 * unit01(rng)) * (double) numRows;
+        const double sx = (0.08 + 0.20 * unit01(rng)) * (double) numCols;
+        const double sy = (0.06 + 0.22 * unit01(rng)) * (double) numRows;
+        const double feather = 2.5 + 4.5 * unit01(rng);
+        const double contrast = (unit01(rng) < 0.35 ? -1.0 : 1.0) * (34.0 + 70.0 * unit01(rng));
+        const double phase = 2.0 * M_PI * unit01(rng);
+        objects.push_back({type, cx, cy, sx, sy, feather, contrast, phase});
+    }
+
+    for (index_t r = 0; r < numRows; ++r) {
+        for (index_t c = 0; c < numCols; ++c) {
+            const index_t p = r * numCols + c;
+            const double y = (double) r;
+            const double x = (double) c;
+
+            const double xn = x / (double) std::max<index_t>(1, numCols - 1);
+            const double yn = y / (double) std::max<index_t>(1, numRows - 1);
+
+            double value = 0.0;
+            if (backgroundFamily == 0) {
+                value = 40.0 + 76.0 * yn + 30.0 * xn;
+                value += 18.0 * std::sin(0.90 * xn + 1.35 * yn);
+                value += 11.0 * std::cos(1.70 * xn - 1.10 * yn);
+            } else if (backgroundFamily == 1) {
+                value = 92.0 + 28.0 * std::sin(3.1 * xn + 2.0 * yn) + 36.0 * (benchmark_fbm(0.8 * y, 0.8 * x, backgroundScales, backgroundSeeds) - 0.5);
+            } else {
+                const double dx = xn - 0.48;
+                const double dy = yn - 0.54;
+                value = 58.0 + 115.0 * std::exp(-(dx * dx / 0.18 + dy * dy / 0.14));
+                value += 20.0 * std::sin(2.8 * xn - 2.2 * yn);
+            }
+
+            const double objectTexture = benchmark_fbm(1.2 * y, 1.2 * x, objectScales, objectSeeds) - 0.5;
+            const double fineTexture = benchmark_value_noise(y, x, 6.0, seed + 0x97531u) - 0.5;
+
+            for (const auto &obj: objects) {
+                double mask = 0.0;
+                if (obj.type == 0) {
+                    mask = benchmark_soft_disk(x, y, obj.cx, obj.cy, obj.sx, obj.feather);
+                } else if (obj.type == 1) {
+                    mask = benchmark_soft_ellipse(x, y, obj.cx, obj.cy, obj.sx, obj.sy, obj.feather);
+                } else if (obj.type == 2) {
+                    mask = benchmark_soft_rect(x, y, obj.cx - obj.sx, obj.cy - obj.sy, obj.cx + obj.sx, obj.cy + obj.sy, obj.feather);
+                } else if (obj.type == 3) {
+                    const double outer = benchmark_soft_disk(x, y, obj.cx, obj.cy, obj.sx, obj.feather);
+                    const double inner = benchmark_soft_disk(x, y, obj.cx, obj.cy, 0.58 * obj.sx, obj.feather);
+                    mask = std::max(0.0, outer - inner);
+                } else {
+                    mask = benchmark_soft_ellipse(x, y, obj.cx, obj.cy, obj.sx, 0.35 * obj.sy, obj.feather);
+                }
+                value += mask * (obj.contrast + 10.0 * objectTexture + 6.0 * std::sin(0.020 * x + 0.024 * y + obj.phase));
+            }
+
+            // Add weak acquisition-like variation without turning the scene into a high-frequency pattern.
+            value += 5.0 * fineTexture;
+            value += 2.5 * std::sin(0.070 * x + 0.045 * y);
+
+            image(p) = clamp_to_u8(value);
+        }
+    }
+
+    return image;
+}
+
+// Dispatches synthetic image generation according to the selected model.
+array_1d<uint8_t> make_benchmark_image(BenchmarkImageModel model, index_t numRows, index_t numCols, uint32_t seed) {
+    switch (model) {
+        case BenchmarkImageModel::natural_like:
+            return make_natural_like_benchmark_image(numRows, numCols, seed);
+        case BenchmarkImageModel::piecewise_scene:
+            return make_piecewise_scene_benchmark_image(numRows, numCols, seed);
+    }
+    hg_assert(false, "Unknown benchmark image model.");
+    return make_natural_like_benchmark_image(numRows, numCols, seed);
+}
+
+// Returns the first n values of the fixed benchmark threshold sequence.
+std::vector<double> make_area_thresholds(int numThresholds) {
+    hg_assert(numThresholds > 0, "Number of thresholds must be positive.");
+    constexpr std::array<int, 32> kThresholdPrefixSequence = {
+            10, 30, 40, 59, 69, 89, 99, 119,
+            138, 148, 168, 178, 198, 217, 227, 247,
+            257, 277, 286, 306, 326, 336, 356, 365,
+            385, 405, 415, 435, 444, 464, 474, 494
+    };
+    hg_assert(numThresholds <= (int) kThresholdPrefixSequence.size(),
+              "Requested number of thresholds exceeds the configured prefix sequence.");
+
+    std::vector<double> thresholds;
+    thresholds.reserve((std::size_t) numThresholds);
+    for (int step = 0; step < numThresholds; ++step) {
+        const double threshold = (double) kThresholdPrefixSequence[(std::size_t) step];
+        if (thresholds.empty() || threshold > thresholds.back()) {
+            thresholds.push_back(threshold);
+        }
+    }
+    return thresholds;
+}
+
+template<typename array_t>
+// Exact image equality check used by pre-benchmark validation.
+bool same_image(const array_t &lhs, const array_t &rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (index_t i = 0; i < (index_t) lhs.size(); ++i) {
+        if (lhs(i) != rhs(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template<typename image_t, typename graph_t>
+// One step of the naive alternating max-tree/min-tree-by-area reference.
+image_t apply_naive_threshold_by_area(const graph_t &graph, const image_t &image, double threshold) {
+    auto maxTree = component_tree_max_tree(graph, image);
+    auto maxArea = attribute_area(maxTree.tree);
+    auto filtered = reconstruct_leaf_data(maxTree.tree, maxTree.altitudes, maxArea <= threshold);
+
+    auto minTree = component_tree_min_tree(graph, filtered);
+    auto minArea = attribute_area(minTree.tree);
+    return reconstruct_leaf_data(minTree.tree, minTree.altitudes, minArea <= threshold);
+}
+
+template<typename image_t, typename graph_t>
+// Applies the full naive threshold sequence by repeatedly rebuilding both trees.
+image_t run_naive_area_sequence(const graph_t &graph, const image_t &image, const std::vector<double> &thresholds) {
+    image_t current = image;
+    for (double threshold: thresholds) {
+        current = apply_naive_threshold_by_area(graph, current, threshold);
+    }
+    return current;
+}
+
+template<typename image_t, typename graph_t>
+// Runs CASF once for the complete threshold sequence.
+image_t run_casf_area_sequence(const graph_t &graph, const image_t &image, const std::vector<double> &thresholds) {
+    ComponentTreeCasf<uint8_t, graph_t> runner(graph, image);
+    return runner.filter(thresholds);
+}
+
+template<typename Fn>
+// Measures wall-clock elapsed time in seconds for a callable.
+double time_seconds(Fn &&fn) {
+    const auto start = std::chrono::steady_clock::now();
+    fn();
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(end - start).count();
+}
+
+struct AreaBenchmarkTiming {
+    double casfSeconds = 0.0;
+    double naiveSeconds = 0.0;
+};
+
+// In-memory representation of one synthetic benchmark case.
+struct BenchmarkSample {
+    std::string label;
+    index_t numRows;
+    index_t numCols;
+    array_1d<uint8_t> image;
+};
+
+constexpr std::array<int, 5> kThresholdRounds = {2, 4, 8, 16, 32};
+
+// Generates the (width, height, threshold-count, seed-index) tuples used in synthetic mode.
+std::vector<std::array<int64_t, 4>> make_benchmark_argument_sets() {
+    std::vector<std::array<int64_t, 4>> args;
+    args.reserve(kThresholdRounds.size() * kBenchmarkSeeds.size());
+    for (int threshold: kThresholdRounds) {
+        for (std::size_t seedIndex = 0; seedIndex < kBenchmarkSeeds.size(); ++seedIndex) {
+            args.push_back({kBenchmarkNumCols, kBenchmarkNumRows, threshold, (int64_t) seedIndex});
+        }
+    }
+    return args;
+}
+
+// Registers all synthetic argument tuples on a google-benchmark instance.
+void apply_small_benchmark_arguments(benchmark::Benchmark *b) {
+    std::vector<std::vector<int64_t>> args;
+    const auto cases = make_benchmark_argument_sets();
+    args.reserve(cases.size());
+    for (const auto &c: cases) {
+        args.push_back({c[0], c[1], c[2], c[3]});
+    }
+    for (const auto &a: args) {
+        b->Args(a);
+    }
+}
+
+template<typename image_t, typename graph_t>
+// Measures both CASF and naive implementations on the same image/threshold set.
+AreaBenchmarkTiming measure_reference_timings(const graph_t &graph, const image_t &image, const std::vector<double> &thresholds) {
+    AreaBenchmarkTiming timing;
+    timing.casfSeconds = time_seconds([&]() {
+        const auto output = run_casf_area_sequence(graph, image, thresholds);
+        benchmark::DoNotOptimize(output.data());
+    });
+    timing.naiveSeconds = time_seconds([&]() {
+        const auto output = run_naive_area_sequence(graph, image, thresholds);
+        benchmark::DoNotOptimize(output.data());
+    });
+    return timing;
+}
+
+template<typename image_t, typename graph_t>
+// Asserts that CASF reproduces exactly the naive reference on a single image.
+void validate_against_naive(const graph_t &graph, const image_t &image, const std::vector<double> &thresholds) {
+    const auto expected = run_naive_area_sequence(graph, image, thresholds);
+    const auto actual = run_casf_area_sequence(graph, image, thresholds);
+    hg_assert(same_image(expected, actual), "CASF and naive outputs must match in the benchmark fixture.");
+}
+
+// Populates the counters shared by all CASF benchmark cases.
+void set_common_counters(benchmark::State &state,
+                         double numThresholds,
+                         double numPixels,
+                         double imageIndex,
+                         double speedupVsNaive) {
+    state.counters["num_thresholds"] = benchmark::Counter(numThresholds, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);
+    state.counters["num_images"] = benchmark::Counter(1.0, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);
+    state.counters["num_pixels"] = benchmark::Counter(numPixels, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);
+    state.counters["image_index"] = benchmark::Counter(imageIndex, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);
+    state.counters["speedup_vs_naive"] = benchmark::Counter(speedupVsNaive);
+}
+
+// Builds one synthetic benchmark sample from a model, resolution and seed index.
+BenchmarkSample make_benchmark_sample(BenchmarkImageModel model, index_t numRows, index_t numCols, std::size_t seedIndex) {
+    hg_assert(seedIndex < kBenchmarkSeeds.size(), "Synthetic benchmark seed index out of range.");
+    const auto seed = kBenchmarkSeeds[seedIndex];
+    return BenchmarkSample{
+            std::string(benchmark_image_model_name(model)) + "_seed_" + std::to_string(seedIndex),
+            numRows,
+            numCols,
+            make_benchmark_image(model, numRows, numCols, seed)
+    };
+}
+
+// Applies the default execution policy shared by all CASF google-benchmark entries.
+void configure_benchmark_statistics(benchmark::Benchmark *b) {
+    b->Iterations(1)->Repetitions(kBenchmarkRepetitions)->MinWarmUpTime(kBenchmarkWarmupSeconds)->ReportAggregatesOnly();
+}
+
+// Synthetic CASF benchmark case: one generated image, one threshold prefix, one seed.
+static void BM_component_tree_casf_area(benchmark::State &state, BenchmarkImageModel model) {
+    const index_t numCols = state.range(0);
+    const index_t numRows = state.range(1);
+    const int numThresholds = (int) state.range(2);
+    const auto seedIndex = (std::size_t) state.range(3);
+    const index_t numPixels = numRows * numCols;
+    const auto sample = make_benchmark_sample(model, numRows, numCols, seedIndex);
+    const auto graph = get_4_adjacency_implicit_graph({numRows, numCols});
+    const auto thresholds = make_area_thresholds(numThresholds);
+    const auto timing = measure_reference_timings(graph, sample.image, thresholds);
+
+    validate_against_naive(graph, sample.image, thresholds);
+    state.SetLabel(benchmark_case_label(model, numThresholds)
+                   + ", resolution=" + std::to_string(numCols) + "x" + std::to_string(numRows)
+                   + ", image=" + sample.label);
+    set_common_counters(state, (double) numThresholds, (double) numPixels, (double) seedIndex, timing.naiveSeconds / timing.casfSeconds);
+
+    for (auto _: state) {
+        const auto output = run_casf_area_sequence(graph, sample.image, thresholds);
+        benchmark::DoNotOptimize(output.data());
+        benchmark::ClobberMemory();
+    }
+}
+
+// Synthetic naive-reference benchmark case matching BM_component_tree_casf_area.
+static void BM_component_tree_casf_naive_area(benchmark::State &state, BenchmarkImageModel model) {
+    const index_t numCols = state.range(0);
+    const index_t numRows = state.range(1);
+    const int numThresholds = (int) state.range(2);
+    const auto seedIndex = (std::size_t) state.range(3);
+    const index_t numPixels = numRows * numCols;
+    const auto sample = make_benchmark_sample(model, numRows, numCols, seedIndex);
+    const auto graph = get_4_adjacency_implicit_graph({numRows, numCols});
+    const auto thresholds = make_area_thresholds(numThresholds);
+
+    validate_against_naive(graph, sample.image, thresholds);
+    state.SetLabel(benchmark_case_label(model, numThresholds)
+                   + ", resolution=" + std::to_string(numCols) + "x" + std::to_string(numRows)
+                   + ", image=" + sample.label);
+    set_common_counters(state, (double) numThresholds, (double) numPixels, (double) seedIndex, 1.0);
+
+    for (auto _: state) {
+        const auto output = run_naive_area_sequence(graph, sample.image, thresholds);
+        benchmark::DoNotOptimize(output.data());
+        benchmark::ClobberMemory();
+    }
+}
+
+} // namespace
+
+namespace {
+bool register_component_tree_casf_benchmarks() {
+    benchmark::RegisterBenchmark("BM_component_tree_casf_area/natural_like", BM_component_tree_casf_area,
+                                 BenchmarkImageModel::natural_like)
+            ->Apply(apply_small_benchmark_arguments)
+            ->Apply(configure_benchmark_statistics);
+    benchmark::RegisterBenchmark("BM_component_tree_casf_area/piecewise_scene", BM_component_tree_casf_area,
+                                 BenchmarkImageModel::piecewise_scene)
+            ->Apply(apply_small_benchmark_arguments)
+            ->Apply(configure_benchmark_statistics);
+    benchmark::RegisterBenchmark("BM_component_tree_casf_naive_area/natural_like", BM_component_tree_casf_naive_area,
+                                 BenchmarkImageModel::natural_like)
+            ->Apply(apply_small_benchmark_arguments)
+            ->Apply(configure_benchmark_statistics);
+    benchmark::RegisterBenchmark("BM_component_tree_casf_naive_area/piecewise_scene", BM_component_tree_casf_naive_area,
+                                 BenchmarkImageModel::piecewise_scene)
+            ->Apply(apply_small_benchmark_arguments)
+            ->Apply(configure_benchmark_statistics);
+    return true;
+}
+const bool component_tree_casf_benchmarks_registered = register_component_tree_casf_benchmarks();
+} // namespace

--- a/benchmark/benchmark_component_tree_casf.cpp
+++ b/benchmark/benchmark_component_tree_casf.cpp
@@ -33,7 +33,7 @@ namespace {
  * -----------------------
  *
  * This benchmark compares the CASF implementation with the naive alternating
- * max-tree/min-tree-by-area reference on synthetic grayscale images.
+ * area-based max-tree/min-tree reference on synthetic grayscale images.
  *
  * Default synthetic mode
  * - One benchmark case corresponds to one generated grayscale image, identified
@@ -68,19 +68,10 @@ namespace {
  *     --benchmark_filter='BM_component_tree_casf_area/.*' \
  *     --benchmark_counters_tabular=true
  *
- * Representative results on Apple Silicon (640x480, 10 seeds, 1 repetition)
- * - natural_like:
- *   thresholds=2  -> about 58-69 ms, speedup about 1.50-1.73
- *   thresholds=4  -> about 61-72 ms, speedup about 2.78-3.18
- *   thresholds=8  -> about 64-74 ms, speedup about 5.29-6.07
- *   thresholds=16 -> about 70-78 ms, speedup about 9.95-11.30
- *   thresholds=32 -> about 78-84 ms, speedup about 15.94-20.16
- * - piecewise_scene:
- *   thresholds=2  -> about 44-48 ms, speedup about 1.89-1.96
- *   thresholds=4  -> about 45-48 ms, speedup about 3.32-3.87
- *   thresholds=8  -> about 45-51 ms, speedup about 7.21-8.00
- *   thresholds=16 -> about 45-48 ms, speedup about 14.20-15.29
- *   thresholds=32 -> about 46-50 ms, speedup about 28.29-31.45
+ * Reporting results
+ * - Timings and speed-ups depend on the hardware, compiler, build flags, and
+ *   current implementation. Record that environment, the commit, and the exact
+ *   invocation whenever benchmark results are reported.
  *
  */
 
@@ -452,7 +443,7 @@ bool same_image(const array_t &lhs, const array_t &rhs) {
 }
 
 template<typename image_t, typename graph_t>
-// One step of the naive alternating max-tree/min-tree-by-area reference.
+// One step of the naive alternating area-based max-tree/min-tree reference.
 image_t apply_naive_threshold_by_area(const graph_t &graph, const image_t &image, double threshold) {
     auto maxTree = component_tree_max_tree(graph, image);
     auto maxArea = attribute_area(maxTree.tree);
@@ -516,7 +507,7 @@ std::vector<std::array<int64_t, 4>> make_benchmark_argument_sets() {
     return args;
 }
 
-// Registers all synthetic argument tuples on a google-benchmark instance.
+// Registers all synthetic argument tuples on a Google Benchmark instance.
 void apply_small_benchmark_arguments(benchmark::Benchmark *b) {
     std::vector<std::vector<int64_t>> args;
     const auto cases = make_benchmark_argument_sets();
@@ -577,7 +568,7 @@ BenchmarkSample make_benchmark_sample(BenchmarkImageModel model, index_t numRows
     };
 }
 
-// Applies the default execution policy shared by all CASF google-benchmark entries.
+// Applies the default execution policy shared by all CASF Google Benchmark entries.
 void configure_benchmark_statistics(benchmark::Benchmark *b) {
     b->Iterations(1)->Repetitions(kBenchmarkRepetitions)->MinWarmUpTime(kBenchmarkWarmupSeconds)->ReportAggregatesOnly();
 }

--- a/doc/source/python/component_tree.rst
+++ b/doc/source/python/component_tree.rst
@@ -7,9 +7,15 @@ Component tree
 
 .. autosummary::
 
-    higra.component_tree_min_tree
-    higra.component_tree_max_tree
+    component_tree_min_tree
+    component_tree_max_tree
+    connected_alternating_sequential_filter
 
 .. autofunction:: higra.component_tree_min_tree
 
 .. autofunction:: higra.component_tree_max_tree
+
+Connected alternating sequential filter
+---------------------------------------
+
+.. autofunction:: higra.connected_alternating_sequential_filter

--- a/higra/hierarchy/CMakeLists.txt
+++ b/higra/hierarchy/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PY_FILES
         __init__.py
         binary_partition_tree.py
         component_tree.py
+        component_tree_dual_filter.py
         constrained_connectivity_hierarchy.py
         hierarchy_core.py
         random_hierarchy.py
@@ -21,6 +22,7 @@ set(PYMODULE_COMPONENTS ${PYMODULE_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/py_binary_partition_tree.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/py_common.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/py_component_tree.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/py_component_tree_dual_filter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/py_hierarchy_core.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/py_watershed_hierarchy.cpp
         PARENT_SCOPE)

--- a/higra/hierarchy/__init__.py
+++ b/higra/hierarchy/__init__.py
@@ -10,6 +10,7 @@
 
 from .binary_partition_tree import *
 from .component_tree import *
+from .component_tree_dual_filter import *
 from .constrained_connectivity_hierarchy import *
 from .hierarchy_core import *
 from .random_hierarchy import *

--- a/higra/hierarchy/component_tree_dual_filter.py
+++ b/higra/hierarchy/component_tree_dual_filter.py
@@ -1,0 +1,52 @@
+############################################################################
+# Copyright ESIEE Paris (2018)                                             #
+#                                                                          #
+# Contributor(s) : Wonder Alexandre Luz Alves                              #
+#                                                                          #
+# Distributed under the terms of the CECILL-B License.                     #
+#                                                                          #
+# The full license is in the file LICENSE, distributed with this software. #
+############################################################################
+
+import higra as hg
+
+
+def _get_attribute_map():
+    return {
+        "area": hg.CasfAttribute.area,
+        "bounding_box_width": hg.CasfAttribute.bounding_box_width,
+        "bounding_box_height": hg.CasfAttribute.bounding_box_height,
+        "bounding_box_diagonal": hg.CasfAttribute.bounding_box_diagonal,
+    }
+
+
+def connected_alternating_sequential_filter(graph, vertex_weights, attribute, thresholds):
+    """
+    Connected alternating sequential filter on a vertex weighted graph.
+
+    The filter alternates an extensive max-tree pruning step and an anti-extensive
+    min-tree pruning step for each threshold in ``thresholds``.
+
+    :param graph: input graph
+    :param vertex_weights: vertex weights of the input graph
+    :param attribute: one of ``"area"``, ``"bounding_box_width"``,
+        ``"bounding_box_height"``, ``"bounding_box_diagonal"``, or the
+        corresponding :class:`~higra.CasfAttribute` value
+    :param thresholds: sequence of thresholds applied successively
+    :return: filtered vertex weights
+    """
+    attribute_map = _get_attribute_map()
+
+    if isinstance(attribute, str):
+        try:
+            attribute = attribute_map[attribute]
+        except KeyError:
+            raise ValueError("Unknown CASF attribute '" + attribute + "'. Expected one of " + str(tuple(attribute_map.keys())) + ".")
+    elif attribute not in attribute_map.values():
+        raise ValueError("attribute must be a string or a higra.CasfAttribute value.")
+
+    vertex_weights = hg.linearize_vertex_weights(vertex_weights, graph)
+
+    filtered_weights = hg.cpp._connected_alternating_sequential_filter(graph, vertex_weights, attribute, thresholds)
+
+    return hg.delinearize_vertex_weights(filtered_weights, graph)

--- a/higra/hierarchy/component_tree_dual_filter.py
+++ b/higra/hierarchy/component_tree_dual_filter.py
@@ -21,19 +21,101 @@ def _get_attribute_map():
 
 
 def connected_alternating_sequential_filter(graph, vertex_weights, attribute, thresholds):
-    """
-    Connected alternating sequential filter on a vertex weighted graph.
+    r"""
+    Connected alternating sequential filter (CASF) on a vertex weighted graph.
 
-    The filter alternates an extensive max-tree pruning step and an anti-extensive
-    min-tree pruning step for each threshold in ``thresholds``.
+    Let :math:`G=(V,E)` be the input graph, :math:`f_0:V\to K` the input
+    vertex weights, and :math:`A` an increasing attribute on the component
+    trees. For a threshold :math:`t`, denote by :math:`\gamma^A_t` the
+    connected attribute opening obtained by pruning max-tree nodes whose
+    attribute value is less than or equal to :math:`t`, and by
+    :math:`\phi^A_t` the corresponding connected attribute closing obtained
+    by pruning min-tree nodes. Given the threshold sequence
+    :math:`T=(t_1,\ldots,t_k)`, this implementation computes
+
+    .. math::
+
+        f_i = \phi^A_{t_i}\!\left(\gamma^A_{t_i}(f_{i-1})\right),
+        \quad i=1,\ldots,k,
+
+    and returns :math:`f_k`. Thus, each threshold applies the anti-extensive
+    attribute opening on the max-tree first, followed by the extensive
+    attribute closing on the min-tree. Thresholds are applied in the order
+    given; a standard alternating sequential filter uses a non-decreasing
+    sequence.
+
+    The max-tree and min-tree are constructed only once. When one tree is
+    pruned, its dual tree and both attributes are updated incrementally, and
+    the filtered vertex weights are reconstructed only after the complete
+    sequence. The update strategy and its complexity analysis are described
+    in [AlvesEtAl2025]_, [AlvesEtAl2026]_.
+
+    :Complexity:
+
+    For bounded-degree image grids and the comparison-based component tree
+    construction analyzed in [AlvesEtAl2026]_, rebuilding a tree at every opening and
+    closing step has time complexity
+    :math:`\mathcal{O}(k |V| \log |V|)`. Let :math:`S_i` denote the roots of
+    the subtrees pruned at iteration :math:`i`, :math:`|C_a|` the size of an
+    affected component, and :math:`|b-a|` the altitude interval involved in
+    the update of its dual tree. Under the same assumptions, the incremental
+    algorithm has time complexity
+
+    .. math::
+
+        \mathcal{O}\!\left(
+            |V|\log |V| +
+            \sum_{i=1}^{k}\sum_{C\in S_i} (|C_a| + |b-a|)
+        \right).
+
+    It is therefore expected to outperform the naive approach when the local
+    update work is smaller than rebuilding the full trees. The gain is usually
+    more pronounced for longer threshold sequences, after the one-time tree
+    construction cost has been amortized. Early iterations that remove large
+    components can be less favorable. For a full CASF run with :math:`k=50`
+    thresholds, the experiments reported in [AlvesEtAl2026]_ show speed-ups of
+    :math:`20.452\times`, :math:`20.643\times`, and :math:`20.572\times` for
+    the update-based implementation over the naive baseline on the 480p,
+    720p, and 1080p versions of the Occluded RoadText Challenge dataset,
+    respectively. These measured speed-ups are indicative rather than
+    guaranteed: actual gains also depend on the input vertex weights,
+    attribute, graph degree, altitude data type, and threshold sequence.
+
+    :Example:
+
+    .. code-block:: python
+
+        import higra as hg
+        import numpy as np
+
+        image = np.asarray(((0, 0, 0, 0, 0),
+                            (0, 7, 7, 0, 0),
+                            (0, 7, 7, 0, 5),
+                            (0, 0, 0, 0, 5),
+                            (0, 0, 0, 0, 0)), dtype=np.uint8)
+        graph = hg.get_4_adjacency_implicit_graph(image.shape)
+        filtered = hg.connected_alternating_sequential_filter(
+            graph, image, "area", thresholds=[1, 2]
+        )
+
+    .. [AlvesEtAl2025] W. A. L. Alves, N. Passat, D. J. Silva, A. Morimitsu, and R. F. Hashimoto,
+       `Efficient Connected Alternating Sequential Filters Based on Component Trees
+       <https://doi.org/10.1007/978-3-032-09544-2_15>`_, DGMM 2025, Lecture Notes in
+       Computer Science, pp. 210-223.
+    .. [AlvesEtAl2026] W. A. L. Alves, N. Passat, D. J. Silva, A. Morimitsu, and R. F. Hashimoto,
+       `Component Tree: Update Rather than Rebuild
+       <https://doi.org/10.1007/s10851-026-01321-w>`_, Journal of Mathematical Imaging
+       and Vision, vol. 68, article 61, 2026.
 
     :param graph: input graph
     :param vertex_weights: vertex weights of the input graph
     :param attribute: one of ``"area"``, ``"bounding_box_width"``,
         ``"bounding_box_height"``, ``"bounding_box_diagonal"``, or the
-        corresponding :class:`~higra.CasfAttribute` value
-    :param thresholds: sequence of thresholds applied successively
-    :return: filtered vertex weights
+        corresponding :class:`~higra.CasfAttribute` value. Bounding-box
+        attributes require a graph with a two-dimensional embedding.
+    :param thresholds: sequence of thresholds applied successively. Use a
+        non-decreasing sequence to obtain a standard CASF.
+    :return: filtered vertex weights with the same shape as ``vertex_weights``
     """
     attribute_map = _get_attribute_map()
 

--- a/higra/hierarchy/py_component_tree_dual_filter.cpp
+++ b/higra/hierarchy/py_component_tree_dual_filter.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "py_component_tree_dual_filter.hpp"
+#include "higra/hierarchy/component_tree_casf.hpp"
+#include "../py_common.hpp"
+#include "xtensor-python/pyarray.hpp"
+#include "xtensor-python/pytensor.hpp"
+
+namespace py_component_tree_dual_filter {
+    template<typename T>
+    using pyarray = xt::pyarray<T>;
+
+    namespace py = pybind11;
+
+    template<typename graph_t>
+    struct def_connected_alternating_sequential_filter {
+        template<typename value_t, typename C>
+        static
+        void def(C &c, const char *doc) {
+            c.def("_connected_alternating_sequential_filter",
+                  [](const graph_t &graph,
+                     const pyarray<value_t> &vertex_weights,
+                     hg::ComponentTreeCasfAttribute attribute,
+                     const std::vector<double> &thresholds) {
+                        hg::ComponentTreeCasf<value_t, graph_t> casf(graph, vertex_weights, attribute);
+                        return casf.filter(thresholds);
+                  },
+                  doc,
+                  py::arg("graph"),
+                  py::arg("vertex_weights").noconvert(),
+                  py::arg("attribute"),
+                  py::arg("thresholds"));
+        }
+    };
+
+    void py_init_component_tree_dual_filter(pybind11::module &m) {
+        py::enum_<hg::ComponentTreeCasfAttribute>(m, "CasfAttribute")
+                .value("area", hg::ComponentTreeCasfAttribute::area)
+                .value("bounding_box_width", hg::ComponentTreeCasfAttribute::bounding_box_width)
+                .value("bounding_box_height", hg::ComponentTreeCasfAttribute::bounding_box_height)
+                .value("bounding_box_diagonal", hg::ComponentTreeCasfAttribute::bounding_box_diagonal);
+
+        add_type_overloads<def_connected_alternating_sequential_filter<hg::ugraph>, HG_TEMPLATE_NUMERIC_TYPES>(m, "Connected alternating sequential filter on a vertex weighted graph.");
+        add_type_overloads<def_connected_alternating_sequential_filter<hg::regular_grid_graph_2d>, HG_TEMPLATE_NUMERIC_TYPES>(m,"Connected alternating sequential filter on a regular grid graph.");
+    }
+}

--- a/higra/hierarchy/py_component_tree_dual_filter.hpp
+++ b/higra/hierarchy/py_component_tree_dual_filter.hpp
@@ -1,7 +1,7 @@
 /***************************************************************************
 * Copyright ESIEE Paris (2018)                                             *
 *                                                                          *
-* Contributor(s) : Benjamin Perret                                         *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
 *                                                                          *
 * Distributed under the terms of the CECILL-B License.                     *
 *                                                                          *
@@ -10,9 +10,8 @@
 
 #pragma once
 
-#include "py_binary_partition_tree.hpp"
-#include "py_common.hpp"
-#include "py_component_tree.hpp"
-#include "py_component_tree_dual_filter.hpp"
-#include "py_hierarchy_core.hpp"
-#include "py_watershed_hierarchy.hpp"
+#include "pybind11/pybind11.h"
+
+namespace py_component_tree_dual_filter {
+    void py_init_component_tree_dual_filter(pybind11::module &m);
+}

--- a/higra/pymodule.cpp
+++ b/higra/pymodule.cpp
@@ -45,6 +45,7 @@ PYBIND11_MODULE(higram, m) {
     py_bipartite_graph::py_init_bipartite_graph(m);
     py_common_hierarchy::py_init_common_hierarchy(m);
     py_component_tree::py_init_component_tree(m);
+    py_component_tree_dual_filter::py_init_component_tree_dual_filter(m);
     py_contour_2d::py_init_contour_2d(m);
     py_embedding::py_init_embedding(m);
     py_graph_accumulator::py_init_graph_accumulator(m);

--- a/include/higra/detail/hierarchy/component_tree_adjustment.hpp
+++ b/include/higra/detail/hierarchy/component_tree_adjustment.hpp
@@ -1,0 +1,876 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <type_traits>
+#include <vector>
+
+#include "higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp"
+#include "higra/graph.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/utils.hpp"
+
+namespace hg::detail::hierarchy {
+
+    namespace testing {
+        // Test-only gateway used to keep the primitive update step private in production code
+        // while preserving direct coverage of the core adjustment routine in unit tests.
+        struct ComponentTreeAdjustmentTestAccess;
+    }
+
+    /**
+     * @brief Incremental updater for paired dynamic min-tree / max-tree hierarchies.
+     * 
+     * This class implements the update-rather-than-rebuild strategy introduced in [1,2]
+     * and used for efficient connected alternating sequential filters. It handles the
+     * structural updates of one component tree when the dual tree undergoes a subtree removal
+     * operation induced by an extensive or anti-extensive connected operator.
+     *
+     * More precisely, when a rooted subtree is removed from one hierarchy, this
+     * helper updates the dual hierarchy in place so that both trees remain
+     * consistent with the same filtered image. The update is performed by
+     * collecting the affected nodes over an altitude interval and merging them
+     * level by level instead of rebuilding the whole dual tree from scratch.
+     *
+     * State managed by this class:
+     *  - two mutable dynamic component trees (`mintree`, `maxtree`);
+     *  - one immutable adjacency graph shared by both trees;
+     *  - one incremental attribute computer and two external attribute
+     *    buffers, used to keep tree attributes synchronized after local
+     *    topology edits.
+     *
+     * Internal notation used by the adjustment routine follows [2]:
+     *  - `nodeCa`: implementation-side representative of the node `C_a^-`
+     *    (equivalently `C_a^+` in Remark 7), i.e. the extremal node of the
+     *    updated tree that contains the set `C` at level `a`;
+     *  - `b`: altitude value of the parent of the removed subtree in the
+     *    complementary hierarchy.
+     *
+     * Backend selection for `mergeNodesByLevel`:
+     *  - dense array-based buckets for small integral altitude domains (8 bits),
+     *    using an order-preserving dense index for signed types;
+     *  - sparse ordered-map buckets for larger integral domains and floating-point altitudes.
+     *
+     * The class does not own the altitude or attribute buffers. Callers are
+     * responsible for keeping these buffers alive and indexed on the global id
+     * space of the associated `DynamicComponentTree`.
+     *
+     * 
+     * References:
+     * 
+     * [1] Wonder Alves, Nicolas Passat, Dênnis José da Silva, Alexandre
+     * Morimitsu, Ronaldo F. Hashimoto. "Efficient connected alternating
+     * sequential filters based on component trees." International Conference on
+     * Discrete Geometry and Mathematical Morphology (DGMM), Nov. 2025,
+     * Groningen, Netherlands.
+     *
+     * [2] Wonder Alves, Nicolas Passat, Dênnis José da Silva, Alexandre
+     * Morimitsu, Ronaldo F. Hashimoto. "Component tree: Update rather than
+     * rebuild." Journal of Mathematical Imaging and Vision, 2026.
+     */
+    template<typename altitude_t, typename graph_t>
+    class ComponentTreeAdjustment {
+    private:
+        using tree_t = DynamicComponentTree;
+        // Friend access is restricted to the test helper so wrappers remain the only
+        // production entry points while unit tests can still exercise updateTree directly.
+        friend struct testing::ComponentTreeAdjustmentTestAccess;
+
+        /**
+         * @brief O(1)-reset mark set based on generation stamps.
+         * @details Entries are considered marked when their stored generation
+         * matches the current one.
+         */
+        class GenerationStampSet {
+        public:
+            using gen_t = uint32_t;
+
+        private:
+            std::vector<gen_t> stamp;
+            gen_t cur = 1;
+
+        public:
+            /**
+             * @brief Creates an empty generation-stamped mark set.
+             */
+            GenerationStampSet() = default;
+
+            /**
+             * @brief Creates a mark set pre-sized for `n` possible indices.
+             */
+            explicit GenerationStampSet(size_t n): stamp(n, 0) {}
+
+            /**
+             * @brief Resizes the mark set and clears all logical marks.
+             */
+            void resize(size_t n) {
+                stamp.assign(n, 0);
+                cur = 1;
+            }
+
+            /**
+             * @brief Marks one index in the current generation.
+             */
+            void mark(size_t idx) noexcept {
+                stamp[idx] = cur;
+            }
+
+            /**
+             * @brief Tests whether one index is marked in the current generation.
+             */
+            bool isMarked(size_t idx) const noexcept {
+                return stamp[idx] == cur;
+            }
+
+            /**
+             * @brief Clears the set in O(1) amortized time.
+             * @details The method advances the active generation. If the
+             * generation counter overflows, the underlying storage is physically
+             * zeroed and the generation is restarted at 1.
+             */
+            void resetAll() {
+                if (++cur == 0) {
+                    std::fill(stamp.begin(), stamp.end(), 0);
+                    cur = 1;
+                }
+            }
+        };
+
+        /**
+         * @brief Returns `true` iff the altitude type should use dense buckets.
+         * @details Dense buckets are enabled only for small integral altitude
+         * domains. Larger integral domains and floating-point types use the
+         * sparse backend.
+         */
+        static constexpr bool usesDenseLevels() {
+            if constexpr (std::is_integral_v<altitude_t>) {
+                // Only integral altitude types have a finite bit-width usable for dense buckets.
+                using unsigned_altitude_t = std::make_unsigned_t<altitude_t>;
+                return std::numeric_limits<unsigned_altitude_t>::digits <= 8;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * @brief True iff `mergeNodesByLevel` uses the dense bucket backend.
+         */
+        static constexpr bool use_dense_levels = usesDenseLevels();
+
+        /**
+         * @brief Collection of merged and nested nodes grouped by altitude.
+         * @details The storage backend of `mergeNodesByLevelStorage_` is selected at compile time:
+         *  - dense array of buckets for small integral altitude domains, with
+         *    an order-preserving dense index for signed types;
+         *  - sparse ordered map for large integral or floating-point domains.
+         */
+        class MergedNodesCollection {
+        private:
+            template<bool dense, typename altitude_type>
+            struct merge_nodes_storage_selector;
+
+            template<typename altitude_type>
+            struct merge_nodes_storage_selector<true, altitude_type> {
+                static constexpr std::size_t domain_size = static_cast<std::size_t>(static_cast<long long>(std::numeric_limits<altitude_type>::max()) - static_cast<long long>(std::numeric_limits<altitude_type>::lowest()) + 1);
+                using type = std::array<std::vector<index_t>, domain_size>;
+            };
+
+            template<typename altitude_type>
+            struct merge_nodes_storage_selector<false, altitude_type> {
+                using type = std::map<altitude_type, std::vector<index_t>>;
+            };
+
+            using merge_nodes_storage_t = typename merge_nodes_storage_selector<use_dense_levels, altitude_t>::type;
+
+            merge_nodes_storage_t mergeNodesByLevelStorage_;
+            std::vector<altitude_t> mergeLevels_;
+            std::vector<index_t> adjacentNodes_;
+            std::vector<index_t> frontierNodesAboveB_;
+            GenerationStampSet visited_;
+            GenerationStampSet visitedAdj_;
+            std::size_t maxBucketSize_ = 0;
+            int currentMergeLevelIndex_ = 0;
+            bool isMaxtree_ = false;
+
+        public:
+            static std::size_t denseBucketIndex(altitude_t level) {
+                if constexpr (std::is_signed_v<altitude_t>) {
+                    return static_cast<std::size_t>(
+                            static_cast<long long>(level) -
+                            static_cast<long long>(std::numeric_limits<altitude_t>::lowest()));
+                } else {
+                    return static_cast<std::size_t>(level);
+                }
+            }
+
+            /**
+             * @brief Creates a merged-node collection sized for `maxNodes`.
+             */
+            explicit MergedNodesCollection(index_t maxNodes = 0): visited_(std::max<index_t>(maxNodes, 0)), visitedAdj_(std::max<index_t>(maxNodes, 0)) {
+            }
+
+            /**
+             * @brief Resets all transient state for a new adjustment step.
+             * @param isMaxtree True for max-tree updates, false for min-tree updates.
+             */
+            void resetCollection(bool isMaxtree) {
+                isMaxtree_ = isMaxtree;
+                for (auto level: mergeLevels_) {
+                    if constexpr (use_dense_levels) {
+                        // Dense backend stores one preallocated bucket per altitude value, using
+                        // an order-preserving dense index for signed altitude domains.
+                        mergeNodesByLevelStorage_[denseBucketIndex(level)].clear();
+                    } else {
+                        // Sparse backend stores only encountered levels in an ordered map.
+                        auto it = mergeNodesByLevelStorage_.find(level);
+                        if (it != mergeNodesByLevelStorage_.end()) {
+                            it->second.clear();
+                        }
+                    }
+                }
+                mergeLevels_.clear();
+                adjacentNodes_.clear();
+                frontierNodesAboveB_.clear();
+                visited_.resetAll();
+                visitedAdj_.resetAll();
+                maxBucketSize_ = 0;
+                currentMergeLevelIndex_ = 0;
+            }
+
+            /**
+             * @brief Returns the bucket associated with one altitude value.
+             */
+            std::vector<index_t> &getMergedNodes(const altitude_t &level) {
+                if constexpr (use_dense_levels) {
+                    // Dense backend resolves the bucket by an order-preserving dense index.
+                    return mergeNodesByLevelStorage_[denseBucketIndex(level)];
+                } else {
+                    // Sparse backend lazily creates/accesses the bucket for this altitude.
+                    return mergeNodesByLevelStorage_[level];
+                }
+            }
+
+            /**
+             * @brief Returns the current list of graph-adjacent nodes.
+             * @details These nodes are adjacent, in the image-domain graph, to
+             * the proper parts of the removed dual subtree. They are the
+             * implementation-side representatives of the nodes connected to `C`
+             * in the theoretical construction.
+             */
+            std::vector<index_t> &getAdjacentNodes() {
+                return adjacentNodes_;
+            }
+
+            /**
+             * @brief Returns the current frontier-node roots stored for `frontierNodesAboveB`.
+             * @details Each stored node is the root of a subtree associated
+             * with adjacent nodes lying beyond `b`.
+             */
+            std::vector<index_t> &getFrontierNodesAboveB() {
+                return frontierNodesAboveB_;
+            }
+
+            /**
+             * @brief Returns the largest bucket size seen during the current build.
+             */
+            std::size_t getMaxBucketSize() const {
+                return maxBucketSize_;
+            }
+
+            /**
+             * @brief Inserts one subtree root into `frontierNodesAboveB` if it has not been seen yet.
+             */
+            void addFrontierNodeAboveB(index_t nodeId) {
+                if (!visited_.isMarked(nodeId)) {
+                    frontierNodesAboveB_.push_back(nodeId);
+                    visited_.mark(nodeId);
+                }
+            }
+
+            /**
+             * @brief Inserts the path from one adjacent node to `nodeCa` into `mergeNodesByLevel`.
+             * @details Nodes are distributed by their altitude and inserted at
+             * most once across the whole collection build.
+             */
+            void addNodesOfPath(const tree_t &tree, const std::vector<altitude_t> &altitude, index_t adjacentNode, index_t nodeCa) {
+                if (visited_.isMarked(adjacentNode)) {
+                    return;
+                }
+                index_t nodeId = adjacentNode;
+                while (nodeId != invalid_index) {
+                    if (!visited_.isMarked(nodeId)) {
+                        auto &bucket = getMergedNodes(altitude[nodeId]);
+                        bucket.push_back(nodeId);
+                        maxBucketSize_ = std::max(maxBucketSize_, bucket.size());
+                        visited_.mark(nodeId);
+                    } else {
+                        break;
+                    }
+                    if (nodeId == nodeCa) {
+                        break;
+                    }
+                    const auto parentId = tree.getNodeParent(nodeId);
+                    nodeId = (parentId == nodeId) ? invalid_index : parentId;
+                }
+            }
+
+            /**
+             * @brief Computes the graph-adjacent nodes of the removed dual subtree.
+             * @details For each proper part of the subtree removed in the dual
+             * tree, the method scans its graph neighbors and keeps the
+             * smallest-component node in the updated tree when that neighbor
+             * lies on the merge side of the altitude sweep. These nodes may
+             * then contribute to `mergeNodesByLevel` or `frontierNodesAboveB`.
+             *
+             * @param tree Tree currently being updated.
+             * @param altitude Altitude buffer associated with `tree`.
+             * @param properPartSetC Proper parts of the removed subtree in the
+             *        dual tree. This vector corresponds to the set `C` in [2].
+             * @param graph Adjacency graph of the image domain shared by both trees.
+             */
+            template<typename graph_type>
+            void computeAdjacentNodes(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, const graph_type &graph) {
+                for (auto p: properPartSetC) {
+                    const auto nodeP = tree.getSmallestComponent(p);
+                    if (nodeP == invalid_index) {
+                        continue;
+                    }
+                    const auto altitudeP = altitude[nodeP];
+                    for (auto q: adjacent_vertex_iterator(p, graph)) {
+                        const auto nodeQ = tree.getSmallestComponent(q);
+                        if (nodeQ == invalid_index) {
+                            continue;
+                        }
+                        const auto altitudeQ = altitude[nodeQ];
+                        if (((isMaxtree_ && altitudeQ > altitudeP) || (!isMaxtree_ && altitudeQ < altitudeP)) && !visitedAdj_.isMarked(nodeQ)) {
+                            adjacentNodes_.push_back(nodeQ);
+                            visitedAdj_.mark(nodeQ);
+                        }
+                    }
+                }
+            }
+
+            /**
+             * @brief Builds `mergeNodesByLevel` and `frontierNodesAboveB` for one subtree-adjustment step.
+             * @details Starting from the set `C` of proper parts removed in the
+             * dual tree, this method first computes the graph-adjacent nodes in
+             * the tree being updated. Each adjacent node is then classified with
+             * respect to the sweep ending at level `b`: if it already lies in
+             * the interval toward `nodeCa`, its path to `nodeCa` is inserted
+             * into `mergeNodesByLevel`; otherwise, the method climbs toward the root to
+             * find the last node that still belongs to the sweep and inserts
+             * either that path into `mergeNodesByLevel` or the resulting frontier node
+             * into `frontierNodesAboveB`.
+             */
+            template<typename graph_type>
+            void build(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, index_t nodeCa, altitude_t b, bool isMaxtree, const graph_type &graph) {
+                resetCollection(isMaxtree);
+                computeAdjacentNodes(tree, altitude, properPartSetC, graph);
+                hg_assert(nodeCa != invalid_index, "nodeCa must map to a valid smallest component.");
+
+                for (auto adjacentNode: adjacentNodes_) {
+                    if ((isMaxtree && altitude[adjacentNode] <= b) || (!isMaxtree && altitude[adjacentNode] >= b)) {
+                        addNodesOfPath(tree, altitude, adjacentNode, nodeCa);
+                    } else {
+                        index_t nodeSubtree = adjacentNode;
+                        index_t n = adjacentNode;
+                        while (n != invalid_index) { // Path from the adjacent node to the root, looking for the last node above b.
+                            if ((isMaxtree && b > altitude[n]) || (!isMaxtree && b < altitude[n])) {
+                                break;
+                            }
+                            nodeSubtree = n;
+                            const auto parentId = tree.getNodeParent(n);
+                            n = (parentId == n) ? invalid_index : parentId;
+                        }
+
+                        if (altitude[nodeSubtree] == b) {
+                            addNodesOfPath(tree, altitude, nodeSubtree, nodeCa);
+                        } else if (tree.getNodeParent(nodeSubtree) != invalid_index && tree.getNodeParent(nodeSubtree) != nodeCa) {
+                            addNodesOfPath(tree, altitude, nodeSubtree, nodeCa);
+                        } else {
+                            addFrontierNodeAboveB(nodeSubtree);
+                        }
+                    }
+                }
+            }
+
+            /**
+             * @brief Builds the ordered list of active levels and returns the first one.
+             */
+            altitude_t firstMergeLevel() {
+                mergeLevels_.clear();
+                if constexpr (use_dense_levels) {
+                    // Dense backend scans the full discrete altitude domain in numeric order.
+                    for (std::size_t i = 0; i < mergeNodesByLevelStorage_.size(); ++i) {
+                        if (!mergeNodesByLevelStorage_[i].empty()) {
+                            mergeLevels_.push_back((altitude_t) i);
+                        }
+                    }
+                } else {
+                    // Sparse backend iterates only over altitude levels that were instantiated.
+                    mergeLevels_.reserve(mergeNodesByLevelStorage_.size());
+                    for (const auto &entry: mergeNodesByLevelStorage_) {
+                        if (!entry.second.empty()) {
+                            mergeLevels_.push_back(entry.first);
+                        }
+                    }
+                }
+
+                if (mergeLevels_.empty()) {
+                    return altitude_t{};
+                }
+
+                currentMergeLevelIndex_ = isMaxtree_ ? (int) mergeLevels_.size() - 1 : 0;
+                return mergeLevels_[currentMergeLevelIndex_];
+            }
+
+            /**
+             * @brief Returns `true` while the current level iterator is valid.
+             */
+            bool hasMergeLevel() const {
+                return !mergeLevels_.empty() && currentMergeLevelIndex_ >= 0 && currentMergeLevelIndex_ < (int) mergeLevels_.size();
+            }
+
+            /**
+             * @brief Advances the ordered level iterator and returns the next level.
+             */
+            altitude_t nextMergeLevel() {
+                currentMergeLevelIndex_ = isMaxtree_ ? currentMergeLevelIndex_ - 1 : currentMergeLevelIndex_ + 1;
+                if (!hasMergeLevel()) {
+                    return altitude_t{};
+                }
+                return mergeLevels_[currentMergeLevelIndex_];
+            }
+        };
+
+    private:
+        tree_t *mintree_ = nullptr;
+        tree_t *maxtree_ = nullptr;
+        const graph_t *graph_ = nullptr;
+        MergedNodesCollection mergeNodesByLevel_;
+        GenerationStampSet removedMarks_;
+        
+        std::vector<index_t> properPartSetC_;
+        std::vector<index_t> nodesPendingRemoval_;
+        const DynamicComponentTreeAttributeComputer<double> *attributeComputer_ = nullptr;
+        std::vector<double> *attributeBufferMin_ = nullptr;
+        std::vector<double> *attributeBufferMax_ = nullptr;
+        const std::vector<altitude_t> *altitudeBufferMin_ = nullptr;
+        const std::vector<altitude_t> *altitudeBufferMax_ = nullptr;
+
+        /**
+         * @brief Detaches a node from its parent, optionally releasing it.
+         * @details Delegates to `DynamicComponentTree::removeChild(parent, node, releaseNode)`.
+         * @param tree Tree containing `nodeId`.
+         * @param nodeId Node to detach.
+         * @param releaseNode True to release the node slot after detaching it.
+         */
+        void disconnect(tree_t *tree, index_t nodeId, bool releaseNode) {
+            hg_assert(tree != nullptr, "disconnect: tree must not be null.");
+            if (tree->isRoot(nodeId)) {
+                return;
+            }
+            const index_t parentId = tree->getNodeParent(nodeId);
+            if (parentId == invalid_index || parentId == nodeId) {
+                return;
+            }
+            tree->removeChild(parentId, nodeId, releaseNode);
+        }
+
+        /**
+         * @brief Returns the attribute buffer associated with one of the two trees.
+         * @param tree Either the min-tree or the max-tree owned by this helper.
+         * @return `nullptr` when no incremental attribute computer is configured.
+         */
+        std::vector<double> *getAttributeBuffer(tree_t *tree) const {
+            if (attributeComputer_ == nullptr) {
+                return nullptr;
+            }
+            return tree == maxtree_ ? attributeBufferMax_ : attributeBufferMin_;
+        }
+
+        /**
+         * @brief Returns the altitude buffer associated with one of the two trees.
+         * @param tree Either the min-tree or the max-tree owned by this helper.
+         * @return `nullptr` when the tree pointer is null.
+         */
+        const std::vector<altitude_t> *getAltitudeBuffer(const tree_t *tree) const {
+            if (tree == nullptr) {
+                return nullptr;
+            }
+            return tree == maxtree_ ? altitudeBufferMax_ : altitudeBufferMin_;
+        }
+
+        /**
+         * @brief Reads the altitude of a node from the configured altitude buffer.
+         * @return The altitude value associated with `nodeId`.
+         */
+        inline altitude_t nodeAltitude(const tree_t *tree, index_t nodeId) const {
+            const auto *buffer = getAltitudeBuffer(tree);
+            hg_assert(buffer != nullptr, "Altitude buffer must be configured before querying node levels.");
+            return (*buffer)[nodeId];
+        }
+
+        /**
+         * @brief Recomputes the incremental attribute of a single node after a local edit.
+         * @details The recomputation uses the registered attribute computer and updates the tree-specific buffer in place.
+         * @param tree Tree containing the edited node.
+         * @param nodeId Edited node whose attribute must be refreshed.
+         */
+        void computeAttributeOnTreeNode(tree_t *tree, index_t nodeId) {
+            if (attributeComputer_ == nullptr || tree == nullptr || nodeId == invalid_index || !tree->isAlive(nodeId)) {
+                return;
+            }
+            auto *buffer = getAttributeBuffer(tree);
+            hg_assert(buffer != nullptr, "Attribute computer configured without a valid buffer.");
+            attributeComputer_->computeAttributeOnNode(*tree, nodeId, *buffer);
+        }
+
+        /**
+         * @brief Moves the removed proper-part set onto the current union node.
+         * @details Any node left without direct proper parts is marked as removable so it can be merged away later in the sweep.
+         * @param tree Tree being updated.
+         * @param unionNode Current union node receiving the removed proper parts.
+         * @param properPartSetC Proper parts collected from the removed subtree. This vector corresponds to the set `C` in [2].
+         */
+        void moveSelectedProperPartsToNode(tree_t *tree, index_t unionNode, const std::vector<index_t> &properPartSetC) {
+            for (auto pixelId: properPartSetC) {
+                const index_t ownerId = tree->getSmallestComponent(pixelId);
+                if (ownerId == invalid_index || ownerId == unionNode) {
+                    continue;
+                }
+
+                tree->moveProperPart(unionNode, ownerId, pixelId);
+
+                if (tree->isAlive(ownerId) && tree->getNumProperParts(ownerId) == 0 && ownerId != unionNode && !removedMarks_.isMarked(ownerId)) {
+                    removedMarks_.mark(ownerId);
+                }
+            }
+        }
+
+        /**
+         * @brief Returns the complementary hierarchy for the current update direction.
+         * @param isMaxtree True if the target tree is the max-tree.
+         */
+        tree_t *getOtherTree(bool isMaxtree) {
+            return isMaxtree ? mintree_ : maxtree_;
+        }
+
+        /**
+         * @brief Reattaches all direct children of `sourceNodeId` under `parentId`.
+         * @details Children order is preserved and proper parts are absorbed as well.
+         */
+        void absorbNodeIntoParent(tree_t *targetTree, index_t parentId, index_t sourceNodeId) {
+            hg_assert(targetTree != nullptr, "targetTree must not be null.");
+            targetTree->moveChildren(parentId, sourceNodeId);
+            targetTree->moveProperParts(parentId, sourceNodeId);
+        }
+
+        /**
+         * @brief Builds the internal merge buckets for one subtree-adjustment step.
+         */
+        void buildMergedCollections(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, index_t nodeCa, altitude_t b, bool isMaxtree) {
+            mergeNodesByLevel_.build(tree, altitude, properPartSetC, nodeCa, b, isMaxtree, *graph_);
+        }
+
+
+        /**
+         * @brief Updates one hierarchy after removing a rooted subtree in the dual hierarchy.
+         * @details The method:
+         * 1. gathers the proper parts of the removed subtree;
+         * 2. finds the representative of `C_a^-` and the altitude interval to sweep;
+         * 3. builds the internal merge collections;
+         * 4. merges nodes level by level;
+         * 5. reconnects the final union node in the updated hierarchy.
+         *
+         * Test-only access is provided through `testing::ComponentTreeAdjustmentTestAccess`.
+         *
+         * @param tree Target hierarchy updated in place.
+         * @param rootIdSubtree Root node of the subtree already removed in the complementary hierarchy.
+         */
+        void updateTree(tree_t *tree, index_t rootIdSubtree) {
+            hg_assert(tree != nullptr, "updateTree: tree must not be null.");
+            hg_assert(rootIdSubtree != invalid_index, "updateTree: rootIdSubtree is invalid.");
+
+            const bool isMaxtree = tree == maxtree_;
+            tree_t *otherTree = getOtherTree(isMaxtree);
+            
+            hg_assert(otherTree != nullptr, "updateTree: complementary tree is null.");
+            hg_assert(rootIdSubtree >= 0 && rootIdSubtree < otherTree->getGlobalIdSpaceSize(), "updateTree: rootIdSubtree must be in complementary-tree bounds.");
+            hg_assert(otherTree->isNode(rootIdSubtree) && otherTree->isAlive(rootIdSubtree), "updateTree: rootIdSubtree must be valid/alive in complementary tree.");
+
+            const index_t parentSubtree = otherTree->getNodeParent(rootIdSubtree);
+            hg_assert(parentSubtree != invalid_index && parentSubtree != rootIdSubtree, "updateTree: rootIdSubtree must be attached in complementary tree.");
+            const altitude_t b = nodeAltitude(otherTree, parentSubtree);
+
+            index_t nodeCa = invalid_index;
+            altitude_t altitudeCa = altitude_t{};
+
+            properPartSetC_.clear();
+            properPartSetC_.reserve(64);
+            for (auto nSubtree: otherTree->getNodeSubtree(rootIdSubtree)) {
+                for (auto p: otherTree->getProperParts(nSubtree)) {
+                    properPartSetC_.push_back(p);
+                
+                    const index_t nodeP = tree->getSmallestComponent(p);
+                    if (nodeP == invalid_index) {
+                        continue;
+                    }
+                    const altitude_t altitudeP = nodeAltitude(tree, nodeP);
+                    if (nodeCa == invalid_index || ((isMaxtree && altitudeP < altitudeCa) || (!isMaxtree && altitudeP > altitudeCa))) {
+                        altitudeCa = altitudeP;
+                        nodeCa = nodeP;
+                    }
+                }
+            }
+            hg_assert(nodeCa != invalid_index, "updateTree: invalid C_a representative.");
+            hg_assert(!properPartSetC_.empty(), "updateTree: expected non-empty proper parts in removed subtree.");
+
+            
+            const auto *targetAltitude = getAltitudeBuffer(tree);
+            hg_assert(targetAltitude != nullptr, "updateTree: altitude buffer must be configured for target tree.");
+            buildMergedCollections(*tree, *targetAltitude, properPartSetC_, nodeCa, b, isMaxtree);
+
+            altitude_t mergeLevel = mergeNodesByLevel_.firstMergeLevel();
+            index_t unionNode;
+            index_t previousUnionNode = invalid_index;
+            removedMarks_.resetAll();
+            nodesPendingRemoval_.reserve(mergeNodesByLevel_.getMaxBucketSize());
+            while (mergeNodesByLevel_.hasMergeLevel() && ((isMaxtree && mergeLevel > altitudeCa) || (!isMaxtree && mergeLevel < altitudeCa))) {
+                auto &mergeNodesAtLevel = mergeNodesByLevel_.getMergedNodes(mergeLevel);
+                unionNode = invalid_index;
+                nodesPendingRemoval_.clear();
+
+                for (auto nodeId: mergeNodesAtLevel) {
+                    if (!tree->isAlive(nodeId)) {
+                        continue;
+                    }
+
+                    if (unionNode == invalid_index) {
+                        if (removedMarks_.isMarked(nodeId)) {
+                            nodesPendingRemoval_.push_back(nodeId);
+                            continue;
+                        }
+                        unionNode = nodeId;
+                        this->disconnect(tree, unionNode, false);
+
+                        for (auto pendingNodeId: nodesPendingRemoval_) {
+                            this->absorbNodeIntoParent(tree, unionNode, pendingNodeId);
+                            this->disconnect(tree, pendingNodeId, true);
+                        }
+                        nodesPendingRemoval_.clear();
+                        continue;
+                    }
+
+                    this->absorbNodeIntoParent(tree, unionNode, nodeId);
+                    this->disconnect(tree, nodeId, true);
+                }
+
+                if (unionNode == invalid_index) {
+                    for (auto nodeId: nodesPendingRemoval_) {
+                        this->absorbNodeIntoParent(tree, tree->getNodeParent(nodeId), nodeId);
+                        this->disconnect(tree, nodeId, true);
+                    }
+                    mergeLevel = mergeNodesByLevel_.nextMergeLevel();
+                    unionNode = previousUnionNode;
+                    continue;
+                }
+
+                if (mergeLevel == b) {
+                    this->moveSelectedProperPartsToNode(tree, unionNode, properPartSetC_);
+                    for (auto nodeId: mergeNodesByLevel_.getFrontierNodesAboveB()) {
+                        this->disconnect(tree, nodeId, false);
+                        tree->attachNode(unionNode, nodeId);
+                    }
+                }
+
+                if (previousUnionNode != invalid_index) {
+                    if (tree->isAlive(previousUnionNode) && !tree->hasChild(unionNode, previousUnionNode)) {
+                        if (!tree->isRoot(previousUnionNode)) {
+                            this->disconnect(tree, previousUnionNode, false);
+                        }
+                        tree->attachNode(unionNode, previousUnionNode);
+                    }
+                }
+
+                computeAttributeOnTreeNode(tree, unionNode);
+
+                previousUnionNode = unionNode;
+                mergeLevel = mergeNodesByLevel_.nextMergeLevel();
+            }
+
+            const index_t finalUnionNode = previousUnionNode;
+            if (finalUnionNode != invalid_index && tree->isAlive(finalUnionNode)) {
+                if (removedMarks_.isMarked(nodeCa)) {
+                    if (!tree->isRoot(nodeCa)) {
+                        const index_t parentIdNodeCa = tree->getNodeParent(nodeCa);
+
+                        if (!tree->isRoot(finalUnionNode)) {
+                            this->disconnect(tree, finalUnionNode, false);
+                        }
+                        tree->attachNode(parentIdNodeCa, finalUnionNode);
+
+                        std::vector<index_t> childrenOfNodeCa;
+                        childrenOfNodeCa.reserve((size_t) tree->getNumChildren(nodeCa));
+                        for (auto n: tree->getChildren(nodeCa)) {
+                            childrenOfNodeCa.push_back(n);
+                        }
+
+                        for (auto n: childrenOfNodeCa) {
+                            if (n != finalUnionNode && !tree->hasChild(finalUnionNode, n)) {
+                                if (!tree->isRoot(n)) {
+                                    this->disconnect(tree, n, false);
+                                }
+                                tree->attachNode(finalUnionNode, n);
+                            }
+                        }
+
+                        this->disconnect(tree, nodeCa, true);
+                        computeAttributeOnTreeNode(tree, finalUnionNode);
+                        computeAttributeOnTreeNode(tree, parentIdNodeCa);
+                    } else {
+                        index_t newRoot = finalUnionNode;
+
+                        std::vector<index_t> childrenOfNodeCa;
+                        childrenOfNodeCa.reserve((size_t) tree->getNumChildren(nodeCa));
+                        for (auto n: tree->getChildren(nodeCa)) {
+                            childrenOfNodeCa.push_back(n);
+                        }
+
+                        for (auto n: childrenOfNodeCa) {
+                            if ((isMaxtree && nodeAltitude(tree, n) < nodeAltitude(tree, newRoot)) || (!isMaxtree && nodeAltitude(tree, n) > nodeAltitude(tree, newRoot))) {
+                                newRoot = n;
+                            }
+                        }
+
+                        if (newRoot != finalUnionNode) {
+                            if (!tree->isRoot(finalUnionNode)) {
+                                this->disconnect(tree, finalUnionNode, false);
+                            }
+                            tree->attachNode(newRoot, finalUnionNode);
+                        }
+
+                        for (auto n: childrenOfNodeCa) {
+                            if (n != newRoot && !tree->hasChild(newRoot, n)) {
+                                if (!tree->isRoot(n)) {
+                                    this->disconnect(tree, n, false);
+                                }
+                                tree->attachNode(newRoot, n);
+                            }
+                        }
+
+                        tree->setRoot(newRoot);
+
+                        tree->releaseNode(nodeCa);
+                        computeAttributeOnTreeNode(tree, newRoot);
+                    }
+                } else if (finalUnionNode != nodeCa) {
+                    if (!tree->isRoot(finalUnionNode)) {
+                        this->disconnect(tree, finalUnionNode, false);
+                    }
+                    tree->attachNode(nodeCa, finalUnionNode);
+                    computeAttributeOnTreeNode(tree, nodeCa);
+                }
+            }
+
+        }
+
+
+    public:
+        /**
+         * @brief Creates an adjustment helper from paired dynamic min/max trees.
+         * @param mintree Dynamic min-tree.
+         * @param maxtree Dynamic max-tree.
+         * @param graph Underlying graph shared by both hierarchies.
+         */
+        ComponentTreeAdjustment(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree), maxtree_(maxtree), graph_(&graph), mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)), removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
+            hg_assert(mintree_ != nullptr, "mintree must not be null.");
+            hg_assert(maxtree_ != nullptr, "maxtree must not be null.");
+            hg_assert(graph_ != nullptr, "graph must not be null.");
+        }
+
+        /**
+         * @brief Defaulted destructor.
+         */
+        virtual ~ComponentTreeAdjustment() = default;
+
+        /**
+         * @brief Registers the incremental attribute computer and its two output buffers.
+         * @details Buffer sizing is the caller's responsibility. Each buffer must be
+         * indexable on the full global id space of its associated dynamic tree.
+         * @param computer Incremental attribute computer used after local edits.
+         * @param bufferMin Output buffer for min-tree attributes.
+         * @param bufferMax Output buffer for max-tree attributes.
+         */
+        void setAttributeComputer(const DynamicComponentTreeAttributeComputer<double> &computer, std::vector<double> &bufferMin, std::vector<double> &bufferMax) {
+            attributeComputer_ = &computer;
+            attributeBufferMin_ = &bufferMin;
+            attributeBufferMax_ = &bufferMax;
+        }
+
+        /**
+         * @brief Registers external altitude arrays for the min-tree and max-tree.
+         * @details The adjustment logic reads node levels exclusively from these buffers.
+         * @param bufferMin Altitude buffer for the min-tree.
+         * @param bufferMax Altitude buffer for the max-tree.
+         */
+        void setAltitudeBuffers(const std::vector<altitude_t> &bufferMin, const std::vector<altitude_t> &bufferMax) {
+            altitudeBufferMin_ = &bufferMin;
+            altitudeBufferMax_ = &bufferMax;
+        }
+    
+        /**
+         * @brief Prunes rooted subtrees from the max-tree and updates the min-tree after each valid prune.
+         */
+        void pruneMaxTreeAndUpdateMinTree(const std::vector<index_t> &nodesToPrune) {
+            hg_assert(mintree_ != nullptr, "pruneMaxTreeAndUpdateMinTree: mintree must not be null.");
+            hg_assert(maxtree_ != nullptr, "pruneMaxTreeAndUpdateMinTree: maxtree must not be null.");
+            for (auto rootSubtree: nodesToPrune) {
+                if (rootSubtree == invalid_index || rootSubtree == maxtree_->getRoot() || !maxtree_->isNode(rootSubtree) || !maxtree_->isAlive(rootSubtree)) {
+                    continue;
+                }
+                updateTree(mintree_, rootSubtree);
+                maxtree_->pruneNode(rootSubtree);
+            }
+        }
+
+        /**
+         * @brief Prunes rooted subtrees from the min-tree and updates the max-tree after each valid prune.
+         */
+        void pruneMinTreeAndUpdateMaxTree(const std::vector<index_t> &nodesToPrune) {
+            hg_assert(mintree_ != nullptr, "pruneMinTreeAndUpdateMaxTree: mintree must not be null.");
+            hg_assert(maxtree_ != nullptr, "pruneMinTreeAndUpdateMaxTree: maxtree must not be null.");
+            for (auto rootSubtree: nodesToPrune) {
+                if (rootSubtree == invalid_index || rootSubtree == mintree_->getRoot() || !mintree_->isNode(rootSubtree) || !mintree_->isAlive(rootSubtree)) {
+                    continue;
+                }
+                updateTree(maxtree_, rootSubtree);
+                mintree_->pruneNode(rootSubtree);
+            }
+        }
+    };
+
+    namespace testing {
+        struct ComponentTreeAdjustmentTestAccess {
+            template<typename altitude_t, typename graph_t>
+            static void updateTree(ComponentTreeAdjustment<altitude_t, graph_t> &adjust, DynamicComponentTree *tree, index_t rootIdSubtree) {
+                adjust.updateTree(tree, rootIdSubtree);
+            }
+        };
+    }
+
+} // namespace hg::detail::hierarchy

--- a/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
+++ b/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
@@ -39,16 +39,28 @@ namespace hg::detail::hierarchy {
     /**
      * @brief Incremental updater for paired dynamic min-tree / max-tree hierarchies.
      * 
-     * This class implements the update-rather-than-rebuild strategy introduced in [1,2]
-     * and used for efficient connected alternating sequential filters. It handles the
-     * structural updates of one component tree when the dual tree undergoes a subtree removal
-     * operation induced by an extensive or anti-extensive connected operator.
+     * This class implements the update-rather-than-rebuild strategy introduced
+     * in [1,2] and used for efficient connected alternating sequential filters.
+     * It handles the structural update of one component tree when the dual tree
+     * undergoes a subtree-removal operation induced by an extensive or
+     * anti-extensive connected operator.
      *
      * More precisely, when a rooted subtree is removed from one hierarchy, this
      * helper updates the dual hierarchy in place so that both trees remain
      * consistent with the same filtered image. The update is performed by
-     * collecting the affected nodes over an altitude interval and merging them
-     * level by level instead of rebuilding the whole dual tree from scratch.
+     * collecting valid adjacent seeds around the induced proper-part set `C`,
+     * climbing each relevant ancestor chain once, and merging nodes level by
+     * level instead of rebuilding the whole dual tree from scratch.
+     *
+     * Public usage model:
+     *  - construct the helper from a dynamic min-tree / max-tree pair and the
+     *    shared adjacency graph;
+     *  - optionally register an incremental attribute computer and the
+     *    attribute buffers to be refreshed after local edits;
+     *  - register the altitude buffers used to query node levels during the
+     *    adjustment;
+     *  - call either `pruneMaxTreeAndUpdateMinTree(...)` or
+     *    `pruneMinTreeAndUpdateMaxTree(...)`.
      *
      * State managed by this class:
      *  - two mutable dynamic component trees (`mintree`, `maxtree`);
@@ -57,12 +69,20 @@ namespace hg::detail::hierarchy {
      *    buffers, used to keep tree attributes synchronized after local
      *    topology edits.
      *
+     * Ownership and lifetime:
+     *  - this class does not own the trees, graph, altitude buffers, or
+     *    attribute buffers;
+     *  - callers must keep these objects alive for the whole lifetime of the
+     *    filter object;
+     *  - the external buffers must be indexed on the global id space of the
+     *    associated `DynamicComponentTree`.
+     *
      * Internal notation used by the adjustment routine follows [2]:
      *  - `nodeCa`: implementation-side representative of the node `C_a^-`
      *    (equivalently `C_a^+` in Remark 7), i.e. the extremal node of the
      *    updated tree that contains the set `C` at level `a`;
      *  - `b`: altitude value of the parent of the removed subtree in the
-     *    complementary hierarchy.
+     *    primal hierarchy.
      *
      * Backend selection for `mergeNodesByLevel`:
      *  - dense array-based buckets for small integral altitude domains
@@ -177,11 +197,11 @@ namespace hg::detail::hierarchy {
         static constexpr bool use_dense_levels = usesDenseLevels();
 
         /**
-         * @brief Collection of merged and nested nodes grouped by altitude.
-         * @details The storage backend of `mergeNodesByLevelStorage_` is selected at compile time:
-         *  - dense array of buckets for small integral altitude domains, with
-         *    an order-preserving dense index for signed types;
-         *  - sparse ordered map for large integral or floating-point domains.
+         * @brief Collection of merged and frontier nodes grouped by altitude.
+         * @details The storage backend of `mergeNodesByLevelStorage_` is chosen
+         * at compile time. Small integral altitude domains use a dense array of
+         * buckets, while larger integral and floating-point domains use a sparse
+         * ordered map.
          */
         class MergedNodesCollection {
         private:
@@ -203,10 +223,10 @@ namespace hg::detail::hierarchy {
 
             merge_nodes_storage_t mergeNodesByLevelStorage_;
             std::vector<altitude_t> mergeLevels_;
-            std::vector<index_t> adjacentNodes_;
             std::vector<index_t> frontierNodesAboveB_;
-            GenerationStampSet visited_;
-            GenerationStampSet visitedAdj_;
+            GenerationStampSet collectedNodeMarks_;
+            GenerationStampSet mergeBucketNodeMarks_;
+            GenerationStampSet adjacentSeedMarks_;
             std::size_t maxBucketSize_ = 0;
             int currentMergeLevelIndex_ = 0;
             bool isMaxtree_ = false;
@@ -225,22 +245,25 @@ namespace hg::detail::hierarchy {
             /**
              * @brief Creates a merged-node collection sized for `maxNodes`.
              */
-            explicit MergedNodesCollection(index_t maxNodes = 0): visited_(std::max<index_t>(maxNodes, 0)), visitedAdj_(std::max<index_t>(maxNodes, 0)) {
+            explicit MergedNodesCollection(index_t maxNodes = 0): collectedNodeMarks_(std::max<index_t>(maxNodes, 0)),
+                                                                   mergeBucketNodeMarks_(std::max<index_t>(maxNodes, 0)),
+                                                                   adjacentSeedMarks_(std::max<index_t>(maxNodes, 0)) {
             }
 
             /**
-             * @brief Resets all transient state for a new adjustment step.
-             * @param isMaxtree True for max-tree updates, false for min-tree updates.
+             * @brief Resets the transient state of one adjustment step.
+             * @param isMaxtree `true` for max-tree updates, `false` for min-tree updates.
              */
             void resetCollection(bool isMaxtree) {
                 isMaxtree_ = isMaxtree;
                 for (auto level: mergeLevels_) {
                     if constexpr (use_dense_levels) {
-                        // Dense backend stores one preallocated bucket per altitude value, using
-                        // an order-preserving dense index for signed altitude domains.
+                        // Dense backend reuses one bucket per altitude value and clears
+                        // only the levels that were active in the previous step.
                         mergeNodesByLevelStorage_[denseBucketIndex(level)].clear();
                     } else {
-                        // Sparse backend stores only encountered levels in an ordered map.
+                        // Sparse backend stores only touched levels, so only those
+                        // buckets need to be cleared here.
                         auto it = mergeNodesByLevelStorage_.find(level);
                         if (it != mergeNodesByLevelStorage_.end()) {
                             it->second.clear();
@@ -248,10 +271,10 @@ namespace hg::detail::hierarchy {
                     }
                 }
                 mergeLevels_.clear();
-                adjacentNodes_.clear();
                 frontierNodesAboveB_.clear();
-                visited_.resetAll();
-                visitedAdj_.resetAll();
+                collectedNodeMarks_.resetAll();
+                mergeBucketNodeMarks_.resetAll();
+                adjacentSeedMarks_.resetAll();
                 maxBucketSize_ = 0;
                 currentMergeLevelIndex_ = 0;
             }
@@ -261,172 +284,91 @@ namespace hg::detail::hierarchy {
              */
             std::vector<index_t> &getMergedNodes(const altitude_t &level) {
                 if constexpr (use_dense_levels) {
-                    // Dense backend resolves the bucket by an order-preserving dense index.
                     return mergeNodesByLevelStorage_[denseBucketIndex(level)];
                 } else {
-                    // Sparse backend lazily creates/accesses the bucket for this altitude.
                     return mergeNodesByLevelStorage_[level];
                 }
             }
 
             /**
-             * @brief Returns the current list of graph-adjacent nodes.
-             * @details These nodes are adjacent, in the image-domain graph, to
-             * the proper parts of the removed dual subtree. They are the
-             * implementation-side representatives of the nodes connected to `C`
-             * in the theoretical construction.
-             */
-            std::vector<index_t> &getAdjacentNodes() {
-                return adjacentNodes_;
-            }
-
-            /**
-             * @brief Returns the current frontier-node roots stored for `frontierNodesAboveB`.
-             * @details Each stored node is the root of a subtree associated
-             * with adjacent nodes lying beyond `b`.
+             * @brief Returns the frontier roots collected above `b`.
+             * @details Each stored node is the root of the first branch that
+             * leaves the merge interval while climbing from a valid adjacent seed.
              */
             std::vector<index_t> &getFrontierNodesAboveB() {
                 return frontierNodesAboveB_;
             }
 
             /**
-             * @brief Returns the largest bucket size seen during the current build.
+             * @brief Returns the largest bucket observed in the current build.
+             * @details This value is used to reserve the sweep worklist.
              */
             std::size_t getMaxBucketSize() const {
                 return maxBucketSize_;
             }
 
             /**
-             * @brief Inserts one subtree root into `frontierNodesAboveB` if it has not been seen yet.
+             * @brief Marks one adjacent seed at most once in the current step.
+             * @return `true` if the seed was accepted now, `false` if it had already been seen.
+             */
+            bool markAdjacentSeed(index_t nodeId) {
+                if (adjacentSeedMarks_.isMarked(nodeId)) {
+                    return false;
+                }
+                adjacentSeedMarks_.mark(nodeId);
+                return true;
+            }
+
+            /**
+             * @brief Registers one frontier root above `b` only once.
              */
             void addFrontierNodeAboveB(index_t nodeId) {
-                if (!visited_.isMarked(nodeId)) {
+                if (!collectedNodeMarks_.isMarked(nodeId)) {
                     frontierNodesAboveB_.push_back(nodeId);
-                    visited_.mark(nodeId);
+                    collectedNodeMarks_.mark(nodeId);
                 }
             }
 
             /**
-             * @brief Inserts the path from one adjacent node to `nodeCa` into `mergeNodesByLevel`.
-             * @details Nodes are distributed by their altitude and inserted at
-             * most once across the whole collection build.
+             * @brief Inserts one node into the bucket of its own altitude.
+             * @details Each visited node is registered only in the bucket of its
+             * own level, without materializing the full ancestor path in advance.
              */
-            void addNodesOfPath(const tree_t &tree, const std::vector<altitude_t> &altitude, index_t adjacentNode, index_t nodeCa) {
-                if (visited_.isMarked(adjacentNode)) {
+            void addMergeNode(const altitude_t *altitude, index_t nodeId) {
+                if (collectedNodeMarks_.isMarked(nodeId)) {
                     return;
                 }
-                index_t nodeId = adjacentNode;
-                while (nodeId != invalid_index) {
-                    if (!visited_.isMarked(nodeId)) {
-                        auto &bucket = getMergedNodes(altitude[nodeId]);
-                        bucket.push_back(nodeId);
-                        maxBucketSize_ = std::max(maxBucketSize_, bucket.size());
-                        visited_.mark(nodeId);
-                    } else {
-                        break;
-                    }
-                    if (nodeId == nodeCa) {
-                        break;
-                    }
-                    const auto parentId = tree.getNodeParent(nodeId);
-                    nodeId = (parentId == nodeId) ? invalid_index : parentId;
-                }
+                auto &bucket = getMergedNodes(altitude[nodeId]);
+                bucket.push_back(nodeId);
+                maxBucketSize_ = std::max(maxBucketSize_, bucket.size());
+                collectedNodeMarks_.mark(nodeId);
+                mergeBucketNodeMarks_.mark(nodeId);
             }
 
             /**
-             * @brief Computes the graph-adjacent nodes of the removed dual subtree.
-             * @details For each proper part of the subtree removed in the dual
-             * tree, the method scans its graph neighbors and keeps the
-             * smallest-component node in the updated tree when that neighbor
-             * lies on the merge side of the altitude sweep. These nodes may
-             * then contribute to `mergeNodesByLevel` or `frontierNodesAboveB`.
-             *
-             * @param tree Tree currently being updated.
-             * @param altitude Altitude buffer associated with `tree`.
-             * @param properPartSetC Proper parts of the removed subtree in the
-             *        dual tree. This vector corresponds to the set `C` in [2].
-             * @param graph Adjacency graph of the image domain shared by both trees.
+             * @brief Tests whether a node was inserted in a merge bucket.
              */
-            template<typename graph_type>
-            void computeAdjacentNodes(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, const graph_type &graph) {
-                for (auto p: properPartSetC) {
-                    const auto nodeP = tree.getSmallestComponent(p);
-                    if (nodeP == invalid_index) {
-                        continue;
-                    }
-                    const auto altitudeP = altitude[nodeP];
-                    for (auto q: adjacent_vertex_iterator(p, graph)) {
-                        const auto nodeQ = tree.getSmallestComponent(q);
-                        if (nodeQ == invalid_index) {
-                            continue;
-                        }
-                        const auto altitudeQ = altitude[nodeQ];
-                        if (((isMaxtree_ && altitudeQ > altitudeP) || (!isMaxtree_ && altitudeQ < altitudeP)) && !visitedAdj_.isMarked(nodeQ)) {
-                            adjacentNodes_.push_back(nodeQ);
-                            visitedAdj_.mark(nodeQ);
-                        }
-                    }
-                }
-            }
-
-            /**
-             * @brief Builds `mergeNodesByLevel` and `frontierNodesAboveB` for one subtree-adjustment step.
-             * @details Starting from the set `C` of proper parts removed in the
-             * dual tree, this method first computes the graph-adjacent nodes in
-             * the tree being updated. Each adjacent node is then classified with
-             * respect to the sweep ending at level `b`: if it already lies in
-             * the interval toward `nodeCa`, its path to `nodeCa` is inserted
-             * into `mergeNodesByLevel`; otherwise, the method climbs toward the root to
-             * find the last node that still belongs to the sweep and inserts
-             * either that path into `mergeNodesByLevel` or the resulting frontier node
-             * into `frontierNodesAboveB`.
-             */
-            template<typename graph_type>
-            void build(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, index_t nodeCa, altitude_t b, bool isMaxtree, const graph_type &graph) {
-                resetCollection(isMaxtree);
-                computeAdjacentNodes(tree, altitude, properPartSetC, graph);
-                hg_assert(nodeCa != invalid_index, "nodeCa must map to a valid smallest component.");
-
-                for (auto adjacentNode: adjacentNodes_) {
-                    if ((isMaxtree && altitude[adjacentNode] <= b) || (!isMaxtree && altitude[adjacentNode] >= b)) {
-                        addNodesOfPath(tree, altitude, adjacentNode, nodeCa);
-                    } else {
-                        index_t nodeSubtree = adjacentNode;
-                        index_t n = adjacentNode;
-                        while (n != invalid_index) { // Path from the adjacent node to the root, looking for the last node above b.
-                            if ((isMaxtree && b > altitude[n]) || (!isMaxtree && b < altitude[n])) {
-                                break;
-                            }
-                            nodeSubtree = n;
-                            const auto parentId = tree.getNodeParent(n);
-                            n = (parentId == n) ? invalid_index : parentId;
-                        }
-
-                        if (altitude[nodeSubtree] == b) {
-                            addNodesOfPath(tree, altitude, nodeSubtree, nodeCa);
-                        } else if (tree.getNodeParent(nodeSubtree) != invalid_index && tree.getNodeParent(nodeSubtree) != nodeCa) {
-                            addNodesOfPath(tree, altitude, nodeSubtree, nodeCa);
-                        } else {
-                            addFrontierNodeAboveB(nodeSubtree);
-                        }
-                    }
-                }
+            bool isMergeNode(index_t nodeId) const {
+                return mergeBucketNodeMarks_.isMarked(nodeId);
             }
 
             /**
              * @brief Builds the ordered list of active levels and returns the first one.
+             * @details The order matches the sweep direction of the current tree:
+             * descending levels for max-tree updates and ascending levels for min-tree updates.
              */
             altitude_t firstMergeLevel() {
                 mergeLevels_.clear();
                 if constexpr (use_dense_levels) {
-                    // Dense backend scans the full discrete altitude domain in numeric order.
+                    // Dense backend scans the discrete altitude domain and keeps only
+                    // the non-empty levels of the current step.
                     for (std::size_t i = 0; i < mergeNodesByLevelStorage_.size(); ++i) {
                         if (!mergeNodesByLevelStorage_[i].empty()) {
                             mergeLevels_.push_back((altitude_t) i);
                         }
                     }
                 } else {
-                    // Sparse backend iterates only over altitude levels that were instantiated.
+                    // Sparse backend iterates only over levels that were instantiated.
                     mergeLevels_.reserve(mergeNodesByLevelStorage_.size());
                     for (const auto &entry: mergeNodesByLevelStorage_) {
                         if (!entry.second.empty()) {
@@ -463,26 +405,33 @@ namespace hg::detail::hierarchy {
         };
 
     private:
+        // Dynamic primal/dual trees and shared domain adjacency.
         tree_t *mintree_ = nullptr;
         tree_t *maxtree_ = nullptr;
         const graph_t *graph_ = nullptr;
+
+        // Transient state of the current adjustment step.
         MergedNodesCollection mergeNodesByLevel_;
         GenerationStampSet removedMarks_;
-        
+        GenerationStampSet pixelsInCMarks_;
+        GenerationStampSet climbedNodeMarks_;
         std::vector<index_t> properPartSetC_;
         std::vector<index_t> nodesPendingRemoval_;
+        std::vector<index_t> removedNodesPendingAbsorption_;
+
+        // Incremental attribute computation and external altitude buffers.
         const DynamicComponentTreeAttributeComputer<double> *attributeComputer_ = nullptr;
         std::vector<double> *attributeBufferMin_ = nullptr;
         std::vector<double> *attributeBufferMax_ = nullptr;
-        const std::vector<altitude_t> *altitudeBufferMin_ = nullptr;
-        const std::vector<altitude_t> *altitudeBufferMax_ = nullptr;
+        const altitude_t *altitudeBufferMinData_ = nullptr;
+        const altitude_t *altitudeBufferMaxData_ = nullptr;
+        std::size_t altitudeBufferMinSize_ = 0;
+        std::size_t altitudeBufferMaxSize_ = 0;
 
         /**
          * @brief Detaches a node from its parent, optionally releasing it.
-         * @details Delegates to `DynamicComponentTree::removeChild(parent, node, releaseNode)`.
-         * @param tree Tree containing `nodeId`.
-         * @param nodeId Node to detach.
-         * @param releaseNode True to release the node slot after detaching it.
+         * @details Delegates to `DynamicComponentTree::removeChild`, preserving
+         * the root case and ignoring nodes with invalid parents.
          */
         void disconnect(tree_t *tree, index_t nodeId, bool releaseNode) {
             hg_assert(tree != nullptr, "disconnect: tree must not be null.");
@@ -497,8 +446,7 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Returns the attribute buffer associated with one of the two trees.
-         * @param tree Either the min-tree or the max-tree owned by this helper.
+         * @brief Returns the attribute buffer associated with one tree.
          * @return `nullptr` when no incremental attribute computer is configured.
          */
         std::vector<double> *getAttributeBuffer(tree_t *tree) const {
@@ -509,32 +457,42 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Returns the altitude buffer associated with one of the two trees.
-         * @param tree Either the min-tree or the max-tree owned by this helper.
-         * @return `nullptr` when the tree pointer is null.
+         * @brief Returns the altitude buffer associated with one tree.
+         * @return `nullptr` when `tree` is null.
          */
-        const std::vector<altitude_t> *getAltitudeBuffer(const tree_t *tree) const {
+        const altitude_t *getAltitudeBufferData(const tree_t *tree) const {
             if (tree == nullptr) {
                 return nullptr;
             }
-            return tree == maxtree_ ? altitudeBufferMax_ : altitudeBufferMin_;
+            return tree == maxtree_ ? altitudeBufferMaxData_ : altitudeBufferMinData_;
         }
 
         /**
-         * @brief Reads the altitude of a node from the configured altitude buffer.
-         * @return The altitude value associated with `nodeId`.
+         * @brief Returns the size of the altitude buffer associated with one tree.
+         */
+        std::size_t getAltitudeBufferSize(const tree_t *tree) const {
+            if (tree == nullptr) {
+                return 0;
+            }
+            return tree == maxtree_ ? altitudeBufferMaxSize_ : altitudeBufferMinSize_;
+        }
+
+        /**
+         * @brief Returns the altitude of one node from the configured buffer.
+         * @details The access is validated against the stored buffer size.
          */
         inline altitude_t nodeAltitude(const tree_t *tree, index_t nodeId) const {
-            const auto *buffer = getAltitudeBuffer(tree);
+            const auto *buffer = getAltitudeBufferData(tree);
+            const auto bufferSize = getAltitudeBufferSize(tree);
             hg_assert(buffer != nullptr, "Altitude buffer must be configured before querying node levels.");
-            return (*buffer)[nodeId];
+            hg_assert(nodeId >= 0 && (std::size_t) nodeId < bufferSize, "Node id must be inside the configured altitude buffer.");
+            return buffer[nodeId];
         }
 
         /**
-         * @brief Recomputes the incremental attribute of a single node after a local edit.
-         * @details The recomputation uses the registered attribute computer and updates the tree-specific buffer in place.
-         * @param tree Tree containing the edited node.
-         * @param nodeId Edited node whose attribute must be refreshed.
+         * @brief Recomputes the incremental attribute of one node after a local edit.
+         * @details The recomputation uses the registered attribute computer and
+         * updates the buffer associated with the edited tree in place.
          */
         void computeAttributeOnTreeNode(tree_t *tree, index_t nodeId) {
             if (attributeComputer_ == nullptr || tree == nullptr || nodeId == invalid_index || !tree->isAlive(nodeId)) {
@@ -547,277 +505,594 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Moves the removed proper-part set onto the current union node.
-         * @details Any node left without direct proper parts is marked as removable so it can be merged away later in the sweep.
-         * @param tree Tree being updated.
-         * @param unionNode Current union node receiving the removed proper parts.
-         * @param properPartSetC Proper parts collected from the removed subtree. This vector corresponds to the set `C` in [2].
+         * @details Any node left without direct proper parts is marked in
+         * `removedMarks_` so it can be contracted later in the step.
          */
-        void moveSelectedProperPartsToNode(tree_t *tree, index_t unionNode, const std::vector<index_t> &properPartSetC) {
+        void moveSelectedProperPartsToNode(tree_t *dualTree, index_t unionNode, const std::vector<index_t> &properPartSetC) {
             for (auto pixelId: properPartSetC) {
-                const index_t ownerId = tree->getSmallestComponent(pixelId);
+                const index_t ownerId = dualTree->getSmallestComponent(pixelId);
                 if (ownerId == invalid_index || ownerId == unionNode) {
                     continue;
                 }
 
-                tree->moveProperPart(unionNode, ownerId, pixelId);
+                dualTree->moveProperPart(unionNode, ownerId, pixelId);
 
-                if (tree->isAlive(ownerId) && tree->getNumProperParts(ownerId) == 0 && ownerId != unionNode && !removedMarks_.isMarked(ownerId)) {
+                if (dualTree->isAlive(ownerId) && dualTree->getNumProperParts(ownerId) == 0 && ownerId != unionNode && !removedMarks_.isMarked(ownerId)) {
                     removedMarks_.mark(ownerId);
+                    removedNodesPendingAbsorption_.push_back(ownerId);
                 }
             }
         }
 
         /**
-         * @brief Returns the complementary hierarchy for the current update direction.
-         * @param isMaxtree True if the target tree is the max-tree.
+         * @brief Tests whether a marked node can still be absorbed.
+         * @details A removable node must still exist, remain alive, stay marked
+         * in `removedMarks_`, and have no direct proper parts.
          */
-        tree_t *getOtherTree(bool isMaxtree) {
+        bool canAbsorbRemovedNode(tree_t *dualTree, index_t nodeId) const {
+            return dualTree != nullptr && nodeId != invalid_index && dualTree->isNode(nodeId) &&
+                   dualTree->isAlive(nodeId) && removedMarks_.isMarked(nodeId) && dualTree->getNumProperParts(nodeId) == 0;
+        }
+
+        /**
+         * @brief Absorbs one removed non-root node into its parent.
+         * @details Children and proper parts are moved to `parentId`, then the
+         * parent attribute is recomputed. If the parent also becomes empty, it is
+         * returned so the contraction can propagate upward.
+         * @return The parent re-enqueued for absorption, or `invalid_index` when
+         * no further propagation is required.
+         */
+        index_t absorbRemovedNonRootNode(tree_t *dualTree, index_t removedNodeId) {
+            const index_t parentId = dualTree->getNodeParent(removedNodeId);
+            if (parentId == invalid_index || parentId == removedNodeId || !dualTree->isAlive(parentId)) {
+                return invalid_index;
+            }
+
+            dualTree->moveChildren(parentId, removedNodeId);
+            dualTree->moveProperParts(parentId, removedNodeId);
+            disconnect(dualTree, removedNodeId, true);
+            computeAttributeOnTreeNode(dualTree, parentId);
+
+            if (dualTree->isAlive(parentId) && dualTree->getNumProperParts(parentId) == 0) {
+                removedMarks_.mark(parentId);
+                return parentId;
+            }
+
+            return invalid_index;
+        }
+
+        /**
+         * @brief Absorbs one removed root node by promoting a surviving child.
+         * @details Among the remaining direct children, the method selects the
+         * representative compatible with the altitude order of the current tree,
+         * reattaches the others below it, and releases the removed root.
+         */
+        void absorbRemovedRootNode(tree_t *dualTree, index_t removedNodeId) {
+            const bool isMaxtree = dualTree == maxtree_;
+            const index_t firstChild = dualTree->getFirstChild(removedNodeId);
+            if (firstChild == invalid_index) {
+                return;
+            }
+
+            index_t newRoot = firstChild;
+            for (auto childId = firstChild; childId != invalid_index; childId = dualTree->getNextSibling(childId)) {
+                if ((isMaxtree && nodeAltitude(dualTree, childId) < nodeAltitude(dualTree, newRoot)) || (!isMaxtree && nodeAltitude(dualTree, childId) > nodeAltitude(dualTree, newRoot))) {
+                    newRoot = childId;
+                }
+            }
+
+            for (auto childId = firstChild; childId != invalid_index;) {
+                const index_t next = dualTree->getNextSibling(childId);
+                if (childId != newRoot && !dualTree->hasChild(newRoot, childId)) {
+                    dualTree->detachNode(childId);
+                    dualTree->attachNode(newRoot, childId);
+                }
+                childId = next;
+            }
+
+            dualTree->setRoot(newRoot);
+            dualTree->releaseNode(removedNodeId);
+            computeAttributeOnTreeNode(dualTree, newRoot);
+        }
+
+        /**
+         * @brief Contracts, in post-order, nodes that remained alive but empty.
+         * @details This pass runs after the level sweep, when the local topology
+         * is already stable. The explicit stack visits only nodes that are still
+         * marked and still empty, skipping obsolete seeds.
+         */
+        void absorbRemovedNodes(tree_t *dualTree, const std::vector<index_t> &removedNodeIds) {
+            struct Frame {
+                index_t nodeId = invalid_index;
+                index_t nextChildId = invalid_index;
+            };
+
+            if (dualTree == nullptr || removedNodeIds.empty()) {
+                return;
+            }
+
+            std::vector<Frame> stack;
+            stack.reserve(std::max<std::size_t>(64, removedNodeIds.size()));
+            const auto makeFrame = [dualTree](index_t nodeId) {
+                return Frame{nodeId, dualTree->getFirstChild(nodeId)};
+            };
+            for (auto it = removedNodeIds.rbegin(); it != removedNodeIds.rend(); ++it) {
+                if (*it != invalid_index) {
+                    stack.push_back(makeFrame(*it));
+                }
+            }
+
+            while (!stack.empty()) {
+                Frame &frame = stack.back();
+                index_t currentNodeId = invalid_index;
+
+                if (!canAbsorbRemovedNode(dualTree, frame.nodeId)) {
+                    stack.pop_back();
+                } else if (frame.nextChildId != invalid_index) {
+                    const index_t childId = frame.nextChildId;
+                    frame.nextChildId = dualTree->getNextSibling(childId);
+                    stack.push_back(makeFrame(childId));
+                } else {
+                    currentNodeId = frame.nodeId;
+                    stack.pop_back();
+                }
+
+                if (canAbsorbRemovedNode(dualTree, currentNodeId)) {
+                    if (dualTree->isRoot(currentNodeId)) {
+                        absorbRemovedRootNode(dualTree, currentNodeId);
+                    } else {
+                        const index_t parentId = absorbRemovedNonRootNode(dualTree, currentNodeId);
+                        if (parentId != invalid_index) {
+                            stack.push_back(makeFrame(parentId));
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * @brief Normalizes one child branch of a removed root to its surviving representative.
+         * @details While the top of the branch remains marked in `removedMarks_`
+         * and has no proper parts, the best child is promoted directly under `rootId`.
+         * This exposes the representative that will actually survive the closure step.
+         */
+        index_t collapseRemovedRootBranch(tree_t *dualTree, index_t rootId, index_t childId) {
+            hg_assert(dualTree != nullptr, "dualTree must not be null.");
+            hg_assert(rootId != invalid_index, "rootId must be valid.");
+            const bool isMaxtree = dualTree == maxtree_;
+
+            index_t current = childId;
+            while (current != invalid_index && dualTree->isNode(current) && dualTree->isAlive(current) && dualTree->getNodeParent(current) == rootId && removedMarks_.isMarked(current) && dualTree->getNumProperParts(current) == 0) {
+                const index_t firstGrandchild = dualTree->getFirstChild(current);
+                if (firstGrandchild == invalid_index) {
+                    break;
+                }
+
+                index_t promoted = firstGrandchild;
+                for (auto grandchildId = firstGrandchild; grandchildId != invalid_index; grandchildId = dualTree->getNextSibling(grandchildId)) {
+                    if ((isMaxtree && nodeAltitude(dualTree, grandchildId) < nodeAltitude(dualTree, promoted)) || (!isMaxtree && nodeAltitude(dualTree, grandchildId) > nodeAltitude(dualTree, promoted))) {
+                        promoted = grandchildId;
+                    }
+                }
+
+                if (!dualTree->isRoot(promoted)) {
+                    disconnect(dualTree, promoted, false);
+                }
+                dualTree->attachNode(rootId, promoted);
+
+                for (auto grandchildId = dualTree->getFirstChild(current); grandchildId != invalid_index;) {
+                    const index_t next = dualTree->getNextSibling(grandchildId);
+                    if (grandchildId != promoted && !dualTree->hasChild(promoted, grandchildId)) {
+                        if (!dualTree->isRoot(grandchildId)) {
+                            disconnect(dualTree, grandchildId, false);
+                        }
+                        dualTree->attachNode(promoted, grandchildId);
+                    }
+                    grandchildId = next;
+                }
+
+                disconnect(dualTree, current, true);
+                computeAttributeOnTreeNode(dualTree, promoted);
+                current = promoted;
+            }
+
+            return current;
+        }
+
+        /**
+         * @brief Finalizes the reconnection between `nodeCa`, `finalUnionNode`, and removed nodes.
+         * @details First resolves the final topological position of the union node
+         * produced by the level sweep. Then contracts, in post-order, the nodes
+         * that remained alive but empty until the end of the step.
+         */
+        void finalizeUpdateTreeAndContractRemovedNodes(tree_t *dualTree, index_t nodeCa, index_t finalUnionNode) {
+            if (dualTree == nullptr) {
+                return;
+            }
+
+            const bool isMaxtree = dualTree == maxtree_;
+
+            if (finalUnionNode != invalid_index && dualTree->isAlive(finalUnionNode)) {
+                if (removedMarks_.isMarked(nodeCa)) {
+                    // If `nodeCa` was emptied, the final union node must occupy its
+                    // topological position in the updated hierarchy.
+                    if (!dualTree->isRoot(nodeCa)) {
+                        const index_t nodeCaParentId = dualTree->getNodeParent(nodeCa);
+
+                        if (!dualTree->isRoot(finalUnionNode)) {
+                            this->disconnect(dualTree, finalUnionNode, false);
+                        }
+                        dualTree->attachNode(nodeCaParentId, finalUnionNode);
+
+                        for (auto childId = dualTree->getFirstChild(nodeCa); childId != invalid_index;) {
+                            const index_t next = dualTree->getNextSibling(childId);
+                            if (childId != finalUnionNode && !dualTree->hasChild(finalUnionNode, childId)) {
+                                if (!dualTree->isRoot(childId)) {
+                                    this->disconnect(dualTree, childId, false);
+                                }
+                                dualTree->attachNode(finalUnionNode, childId);
+                            }
+                            childId = next;
+                        }
+
+                        this->disconnect(dualTree, nodeCa, true);
+                        computeAttributeOnTreeNode(dualTree, finalUnionNode);
+                        computeAttributeOnTreeNode(dualTree, nodeCaParentId);
+                    } else {
+                        // When `nodeCa` is the root, each child branch is reduced to
+                        // its immediate surviving representative before choosing the new root.
+                        index_t survivingFinalUnionNode = finalUnionNode;
+
+                        for (auto childId = dualTree->getFirstChild(nodeCa); childId != invalid_index;) {
+                            const index_t next = dualTree->getNextSibling(childId);
+                            const index_t normalizedChild = collapseRemovedRootBranch(dualTree, nodeCa, childId);
+                            if (childId == finalUnionNode && normalizedChild != invalid_index) {
+                                survivingFinalUnionNode = normalizedChild;
+                            }
+                            childId = next;
+                        }
+
+                        index_t candidateRootId = survivingFinalUnionNode;
+                        // The new root must respect the altitude order of the current tree.
+                        for (auto childId = dualTree->getFirstChild(nodeCa); childId != invalid_index; childId = dualTree->getNextSibling(childId)) {
+                            if ((isMaxtree && nodeAltitude(dualTree, childId) < nodeAltitude(dualTree, candidateRootId)) ||
+                                (!isMaxtree && nodeAltitude(dualTree, childId) > nodeAltitude(dualTree, candidateRootId))) {
+                                candidateRootId = childId;
+                            }
+                        }
+
+                        if (candidateRootId != survivingFinalUnionNode) {
+                            if (!dualTree->isRoot(survivingFinalUnionNode)) {
+                                this->disconnect(dualTree, survivingFinalUnionNode, false);
+                            }
+                            dualTree->attachNode(candidateRootId, survivingFinalUnionNode);
+                        }
+
+                        for (auto childId = dualTree->getFirstChild(nodeCa); childId != invalid_index;) {
+                            const index_t next = dualTree->getNextSibling(childId);
+                            if (childId != candidateRootId && !dualTree->hasChild(candidateRootId, childId)) {
+                                if (!dualTree->isRoot(childId)) {
+                                    this->disconnect(dualTree, childId, false);
+                                }
+                                dualTree->attachNode(candidateRootId, childId);
+                            }
+                            childId = next;
+                        }
+
+                        dualTree->setRoot(candidateRootId);
+                        dualTree->releaseNode(nodeCa);
+                        computeAttributeOnTreeNode(dualTree, candidateRootId);
+                    }
+                } else {
+                    // If `nodeCa` survived, the final union node becomes its child.
+                    if (!dualTree->isRoot(finalUnionNode)) {
+                        this->disconnect(dualTree, finalUnionNode, false);
+                    }
+                    dualTree->attachNode(nodeCa, finalUnionNode);
+                    computeAttributeOnTreeNode(dualTree, nodeCa);
+                }
+            }
+
+            absorbRemovedNodes(dualTree, removedNodesPendingAbsorption_);
+        }
+
+        /**
+         * @brief Returns the primal hierarchy for one update direction.
+         */
+        tree_t *getPrimalTree(bool isMaxtree) {
             return isMaxtree ? mintree_ : maxtree_;
         }
 
         /**
-         * @brief Reattaches all direct children of `sourceNodeId` under `parentId`.
-         * @details Children order is preserved and proper parts are absorbed as well.
+         * @brief Reattaches under `targetNodeId` only the direct children of `sourceNodeId` outside `Γ[a,b]`.
+         * @details Children still marked as belonging to the merge interval are
+         * detached and left isolated until their own sweep level is processed.
          */
-        void absorbNodeIntoParent(tree_t *targetTree, index_t parentId, index_t sourceNodeId) {
-            hg_assert(targetTree != nullptr, "targetTree must not be null.");
-            targetTree->moveChildren(parentId, sourceNodeId);
-            targetTree->moveProperParts(parentId, sourceNodeId);
+        void reattachOutsideIntervalChildren(tree_t *tree, index_t targetNodeId, index_t sourceNodeId) {
+            hg_assert(tree != nullptr, "tree must not be null.");
+            if (sourceNodeId == targetNodeId) {
+                for (auto childId = tree->getFirstChild(sourceNodeId); childId != invalid_index;) {
+                    const index_t next = tree->getNextSibling(childId);
+                    if (mergeNodesByLevel_.isMergeNode(childId)) {
+                        tree->detachNode(childId);
+                    }
+                    childId = next;
+                }
+                return;
+            }
+
+            for (auto childId = tree->getFirstChild(sourceNodeId); childId != invalid_index;) {
+                const index_t next = tree->getNextSibling(childId);
+                if (mergeNodesByLevel_.isMergeNode(childId)) {
+                    tree->detachNode(childId);
+                }
+                childId = next;
+            }
+
+            tree->moveChildren(targetNodeId, sourceNodeId);
         }
 
         /**
-         * @brief Builds the internal merge buckets for one subtree-adjustment step.
+         * @brief Builds `mergeNodesByLevel_` and `frontierNodesAboveB_` for one adjustment step.
+         * @details The method scans graph neighbors of the proper-part set `C`,
+         * filters valid adjacent seeds, and climbs each relevant ancestor chain
+         * at most once. Each visited node is inserted either in the bucket of its
+         * own level or, when above `b`, in `frontierNodesAboveB_`.
          */
-        void buildMergedCollections(const tree_t &tree, const std::vector<altitude_t> &altitude, const std::vector<index_t> &properPartSetC, index_t nodeCa, altitude_t b, bool isMaxtree) {
-            mergeNodesByLevel_.build(tree, altitude, properPartSetC, nodeCa, b, isMaxtree, *graph_);
+        void buildMergedAndNestedCollections(const tree_t &tree, const altitude_t *altitude, const std::vector<index_t> &properPartSetC, index_t nodeCa, altitude_t b, bool isMaxtree) {
+            mergeNodesByLevel_.resetCollection(isMaxtree);
+            hg_assert(nodeCa != invalid_index, "nodeCa must map to a valid smallest component.");
+            climbedNodeMarks_.resetAll();
+            const altitude_t altitudeCa = altitude[nodeCa];
+
+            // For each proper part of `C`, collect valid adjacent seeds and climb
+            // only once through each relevant ancestor chain.
+            for (auto p: properPartSetC) {
+                for (auto q: adjacent_vertex_iterator(p, *graph_)) {
+                    if (pixelsInCMarks_.isMarked(q)) {
+                        continue; // Neighbors internal to `C` do not generate adjacent seeds.
+                    }
+
+                    const index_t nodeQ = tree.getSmallestComponent(q);
+                    if (nodeQ == invalid_index) {
+                        continue; // Pixels without a live component do not enter the collection.
+                    }
+
+                    const altitude_t altitudeQ = altitude[nodeQ];
+                    const bool validSeed = (isMaxtree && altitudeQ >= altitudeCa) || (!isMaxtree && altitudeQ <= altitudeCa);
+                    if (!validSeed) {
+                        continue; // Seeds outside the valid interval do not participate in the merge.
+                    }
+
+                    if (mergeNodesByLevel_.markAdjacentSeed(nodeQ)) {
+                        index_t nodeSubtree = nodeQ;
+                        index_t n = nodeQ;
+                        while (n != invalid_index && tree.isAlive(n) && !climbedNodeMarks_.isMarked(n)) {
+                            const altitude_t levelCurrent = altitude[n];
+                            if (!((isMaxtree && levelCurrent >= altitudeCa) || (!isMaxtree && levelCurrent <= altitudeCa))) {
+                                break; // The climb left the level interval induced by `C`.
+                            }
+
+                            climbedNodeMarks_.mark(n);
+                            nodeSubtree = n;
+
+                            if ((isMaxtree && levelCurrent <= b) || (!isMaxtree && levelCurrent >= b)) {
+                                mergeNodesByLevel_.addMergeNode(altitude, nodeSubtree);
+                            } else {
+                                auto parentId = tree.getNodeParent(nodeSubtree);
+                                if (parentId == nodeSubtree) {
+                                    parentId = invalid_index;
+                                }
+                                if (!(parentId != invalid_index && ((isMaxtree && altitude[parentId] > b) || (!isMaxtree && altitude[parentId] < b)))) {
+                                    mergeNodesByLevel_.addFrontierNodeAboveB(nodeSubtree);
+                                }
+                            }
+
+                            const auto parentId = tree.getNodeParent(n);
+                            if (parentId == n) {
+                                break; // Reached the structural top of this path.
+                            }
+                            n = parentId;
+                        }
+                    }
+                }
+            }
         }
 
 
         /**
-         * @brief Updates one hierarchy after removing a rooted subtree in the dual hierarchy.
+         * @brief Updates one hierarchy after removing a rooted subtree in the primal hierarchy.
          * @details The method:
-         * 1. gathers the proper parts of the removed subtree;
+         * 1. collects the proper parts of the removed subtree in the primal tree;
          * 2. finds the representative of `C_a^-` and the altitude interval to sweep;
-         * 3. builds the internal merge collections;
+         * 3. builds the merge collections;
          * 4. merges nodes level by level;
          * 5. reconnects the final union node in the updated hierarchy.
-         *
-         * Test-only access is provided through `testing::DualMinMaxTreeIncrementalFilterTestAccess`.
-         *
-         * @param tree Target hierarchy updated in place.
-         * @param rootIdSubtree Root node of the subtree already removed in the complementary hierarchy.
          */
-        void updateTree(tree_t *tree, index_t rootIdSubtree) {
-            hg_assert(tree != nullptr, "updateTree: tree must not be null.");
-            hg_assert(rootIdSubtree != invalid_index, "updateTree: rootIdSubtree is invalid.");
+        void updateTree(tree_t *dualTree, index_t subtreeRoot) {
+            hg_assert(dualTree != nullptr, "updateTree: dualTree must not be null.");
+            hg_assert(subtreeRoot != invalid_index, "updateTree: subtreeRoot is invalid.");
 
-            const bool isMaxtree = tree == maxtree_;
-            tree_t *otherTree = getOtherTree(isMaxtree);
+            const bool isMaxtree = dualTree == maxtree_;
+            tree_t *primalTree = getPrimalTree(isMaxtree);
             
-            hg_assert(otherTree != nullptr, "updateTree: complementary tree is null.");
-            hg_assert(rootIdSubtree >= 0 && rootIdSubtree < otherTree->getGlobalIdSpaceSize(), "updateTree: rootIdSubtree must be in complementary-tree bounds.");
-            hg_assert(otherTree->isNode(rootIdSubtree) && otherTree->isAlive(rootIdSubtree), "updateTree: rootIdSubtree must be valid/alive in complementary tree.");
+            hg_assert(primalTree != nullptr, "updateTree: primal tree is null.");
+            hg_assert(subtreeRoot >= 0 && subtreeRoot < primalTree->getGlobalIdSpaceSize(), "updateTree: subtreeRoot must be in primal-tree bounds.");
+            hg_assert(primalTree->isNode(subtreeRoot) && primalTree->isAlive(subtreeRoot), "updateTree: subtreeRoot must be valid/alive in primal tree.");
 
-            const index_t parentSubtree = otherTree->getNodeParent(rootIdSubtree);
-            hg_assert(parentSubtree != invalid_index && parentSubtree != rootIdSubtree, "updateTree: rootIdSubtree must be attached in complementary tree.");
-            const altitude_t b = nodeAltitude(otherTree, parentSubtree);
+            const index_t subtreeParentId = primalTree->getNodeParent(subtreeRoot);
+            hg_assert(subtreeParentId != invalid_index && subtreeParentId != subtreeRoot, "updateTree: subtreeRoot must be attached in primal tree.");
+            const altitude_t b = nodeAltitude(primalTree, subtreeParentId);
 
             index_t nodeCa = invalid_index;
             altitude_t altitudeCa = altitude_t{};
 
+            // Phase 1: collect the set `C` in the primal tree and locate `nodeCa`
+            // as the extreme representative of `C` in the updated tree.
             properPartSetC_.clear();
             properPartSetC_.reserve(64);
-            for (auto nSubtree: otherTree->getNodeSubtree(rootIdSubtree)) {
-                for (auto p: otherTree->getProperParts(nSubtree)) {
+            pixelsInCMarks_.resetAll();
+            for (auto subtreeNodeId: primalTree->getNodeSubtree(subtreeRoot)) {
+                for (auto p: primalTree->getProperParts(subtreeNodeId)) {
                     properPartSetC_.push_back(p);
+                    pixelsInCMarks_.mark(p);
                 
-                    const index_t nodeP = tree->getSmallestComponent(p);
+                    const index_t nodeP = dualTree->getSmallestComponent(p);
                     if (nodeP == invalid_index) {
-                        continue;
+                        continue; // Proper parts without a live dual component do not contribute to `nodeCa`.
                     }
-                    const altitude_t altitudeP = nodeAltitude(tree, nodeP);
+                    const altitude_t altitudeP = nodeAltitude(dualTree, nodeP);
                     if (nodeCa == invalid_index || ((isMaxtree && altitudeP < altitudeCa) || (!isMaxtree && altitudeP > altitudeCa))) {
                         altitudeCa = altitudeP;
                         nodeCa = nodeP;
                     }
                 }
             }
+            if (properPartSetC_.empty()) {
+                return;
+            }
             hg_assert(nodeCa != invalid_index, "updateTree: invalid C_a representative.");
             hg_assert(!properPartSetC_.empty(), "updateTree: expected non-empty proper parts in removed subtree.");
 
             
-            const auto *targetAltitude = getAltitudeBuffer(tree);
+            const auto *targetAltitude = getAltitudeBufferData(dualTree);
             hg_assert(targetAltitude != nullptr, "updateTree: altitude buffer must be configured for target tree.");
-            buildMergedCollections(*tree, *targetAltitude, properPartSetC_, nodeCa, b, isMaxtree);
 
-            altitude_t mergeLevel = mergeNodesByLevel_.firstMergeLevel();
-            index_t unionNode;
-            index_t previousUnionNode = invalid_index;
+            // Phase 2: build the merge buckets by level and the frontier roots above `b`.
+            buildMergedAndNestedCollections(*dualTree, targetAltitude, properPartSetC_, nodeCa, b, isMaxtree);
+
+            // Phase 3: sweep the active levels between `b` and `a`, merging the
+            // buckets and propagating the union node created at each level.
+            altitude_t currentMergeLevel = mergeNodesByLevel_.firstMergeLevel();
+            index_t currentUnionNode;
+            index_t previousLevelUnionNode = invalid_index;
             removedMarks_.resetAll();
+            removedNodesPendingAbsorption_.clear();
             nodesPendingRemoval_.reserve(mergeNodesByLevel_.getMaxBucketSize());
-            while (mergeNodesByLevel_.hasMergeLevel() && ((isMaxtree && mergeLevel > altitudeCa) || (!isMaxtree && mergeLevel < altitudeCa))) {
-                auto &mergeNodesAtLevel = mergeNodesByLevel_.getMergedNodes(mergeLevel);
-                unionNode = invalid_index;
+            while (mergeNodesByLevel_.hasMergeLevel() && ((isMaxtree && currentMergeLevel > altitudeCa) || (!isMaxtree && currentMergeLevel < altitudeCa))) {
+                auto &nodesAtCurrentLevel = mergeNodesByLevel_.getMergedNodes(currentMergeLevel);
+                currentUnionNode = invalid_index;
                 nodesPendingRemoval_.clear();
 
-                for (auto nodeId: mergeNodesAtLevel) {
-                    if (!tree->isAlive(nodeId)) {
-                        continue;
+                for (auto nodeId: nodesAtCurrentLevel) {
+                    if (!dualTree->isAlive(nodeId)) {
+                        continue; // Nodes already removed before this level are ignored.
                     }
 
-                    if (unionNode == invalid_index) {
+                    if (currentUnionNode == invalid_index) {
                         if (removedMarks_.isMarked(nodeId)) {
+                            // If the first candidate at this level was already emptied
+                            // when moving proper parts, keep it pending until an actual
+                            // union node appears at this level.
                             nodesPendingRemoval_.push_back(nodeId);
                             continue;
                         }
-                        unionNode = nodeId;
-                        this->disconnect(tree, unionNode, false);
+                        // The first surviving node of the level becomes the current union node.
+                        currentUnionNode = nodeId;
+                        this->disconnect(dualTree, currentUnionNode, false);
+                        this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, currentUnionNode);
 
+                        // Nodes that were already empty at this level are absorbed into
+                        // the first effective union node that survives the sweep.
                         for (auto pendingNodeId: nodesPendingRemoval_) {
-                            this->absorbNodeIntoParent(tree, unionNode, pendingNodeId);
-                            this->disconnect(tree, pendingNodeId, true);
+                            this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, pendingNodeId);
+                            dualTree->moveProperParts(currentUnionNode, pendingNodeId);
+                            this->disconnect(dualTree, pendingNodeId, true);
                         }
                         nodesPendingRemoval_.clear();
                         continue;
                     }
 
-                    this->absorbNodeIntoParent(tree, unionNode, nodeId);
-                    this->disconnect(tree, nodeId, true);
+                    this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, nodeId);
+                    dualTree->moveProperParts(currentUnionNode, nodeId);
+                    this->disconnect(dualTree, nodeId, true);
                 }
 
-                if (unionNode == invalid_index) {
+                if (currentUnionNode == invalid_index) {
+                    // If no union node survived at this level, finish collapsing the
+                    // pending empty nodes into their current parents and move on.
                     for (auto nodeId: nodesPendingRemoval_) {
-                        this->absorbNodeIntoParent(tree, tree->getNodeParent(nodeId), nodeId);
-                        this->disconnect(tree, nodeId, true);
+                        if (!dualTree->isAlive(nodeId) || dualTree->isRoot(nodeId)) {
+                            continue;
+                        }
+                        const auto parentId = dualTree->getNodeParent(nodeId);
+                        dualTree->moveChildren(parentId, nodeId);
+                        dualTree->moveProperParts(parentId, nodeId);
+                        this->disconnect(dualTree, nodeId, true);
                     }
-                    mergeLevel = mergeNodesByLevel_.nextMergeLevel();
-                    unionNode = previousUnionNode;
+                    currentMergeLevel = mergeNodesByLevel_.nextMergeLevel();
+                    currentUnionNode = previousLevelUnionNode;
                     continue;
                 }
 
-                if (mergeLevel == b) {
-                    this->moveSelectedProperPartsToNode(tree, unionNode, properPartSetC_);
+                if (currentMergeLevel == b) {
+                    // When the sweep reaches `b`, move the set `C` onto the current
+                    // union node and reconnect the frontier branches above `b`.
+                    this->moveSelectedProperPartsToNode(dualTree, currentUnionNode, properPartSetC_);
                     for (auto nodeId: mergeNodesByLevel_.getFrontierNodesAboveB()) {
-                        this->disconnect(tree, nodeId, false);
-                        tree->attachNode(unionNode, nodeId);
+                        this->disconnect(dualTree, nodeId, false);
+                        dualTree->attachNode(currentUnionNode, nodeId);
                     }
                 }
 
-                if (previousUnionNode != invalid_index) {
-                    if (tree->isAlive(previousUnionNode) && !tree->hasChild(unionNode, previousUnionNode)) {
-                        if (!tree->isRoot(previousUnionNode)) {
-                            this->disconnect(tree, previousUnionNode, false);
+                if (previousLevelUnionNode != invalid_index) {
+                    // The union node produced at the previous level becomes a child of
+                    // the current level union node when both still survive.
+                    if (dualTree->isAlive(previousLevelUnionNode) && !dualTree->hasChild(currentUnionNode, previousLevelUnionNode)) {
+                        if (!dualTree->isRoot(previousLevelUnionNode)) {
+                            this->disconnect(dualTree, previousLevelUnionNode, false);
                         }
-                        tree->attachNode(unionNode, previousUnionNode);
+                        dualTree->attachNode(currentUnionNode, previousLevelUnionNode);
                     }
                 }
 
-                computeAttributeOnTreeNode(tree, unionNode);
+                computeAttributeOnTreeNode(dualTree, currentUnionNode);
 
-                previousUnionNode = unionNode;
-                mergeLevel = mergeNodesByLevel_.nextMergeLevel();
+                previousLevelUnionNode = currentUnionNode;
+                currentMergeLevel = mergeNodesByLevel_.nextMergeLevel();
             }
 
-            const index_t finalUnionNode = previousUnionNode;
-            if (finalUnionNode != invalid_index && tree->isAlive(finalUnionNode)) {
-                if (removedMarks_.isMarked(nodeCa)) {
-                    if (!tree->isRoot(nodeCa)) {
-                        const index_t parentIdNodeCa = tree->getNodeParent(nodeCa);
-
-                        if (!tree->isRoot(finalUnionNode)) {
-                            this->disconnect(tree, finalUnionNode, false);
-                        }
-                        tree->attachNode(parentIdNodeCa, finalUnionNode);
-
-                        std::vector<index_t> childrenOfNodeCa;
-                        childrenOfNodeCa.reserve((size_t) tree->getNumChildren(nodeCa));
-                        for (auto n: tree->getChildren(nodeCa)) {
-                            childrenOfNodeCa.push_back(n);
-                        }
-
-                        for (auto n: childrenOfNodeCa) {
-                            if (n != finalUnionNode && !tree->hasChild(finalUnionNode, n)) {
-                                if (!tree->isRoot(n)) {
-                                    this->disconnect(tree, n, false);
-                                }
-                                tree->attachNode(finalUnionNode, n);
-                            }
-                        }
-
-                        this->disconnect(tree, nodeCa, true);
-                        computeAttributeOnTreeNode(tree, finalUnionNode);
-                        computeAttributeOnTreeNode(tree, parentIdNodeCa);
-                    } else {
-                        index_t newRoot = finalUnionNode;
-
-                        std::vector<index_t> childrenOfNodeCa;
-                        childrenOfNodeCa.reserve((size_t) tree->getNumChildren(nodeCa));
-                        for (auto n: tree->getChildren(nodeCa)) {
-                            childrenOfNodeCa.push_back(n);
-                        }
-
-                        for (auto n: childrenOfNodeCa) {
-                            if ((isMaxtree && nodeAltitude(tree, n) < nodeAltitude(tree, newRoot)) || (!isMaxtree && nodeAltitude(tree, n) > nodeAltitude(tree, newRoot))) {
-                                newRoot = n;
-                            }
-                        }
-
-                        if (newRoot != finalUnionNode) {
-                            if (!tree->isRoot(finalUnionNode)) {
-                                this->disconnect(tree, finalUnionNode, false);
-                            }
-                            tree->attachNode(newRoot, finalUnionNode);
-                        }
-
-                        for (auto n: childrenOfNodeCa) {
-                            if (n != newRoot && !tree->hasChild(newRoot, n)) {
-                                if (!tree->isRoot(n)) {
-                                    this->disconnect(tree, n, false);
-                                }
-                                tree->attachNode(newRoot, n);
-                            }
-                        }
-
-                        tree->setRoot(newRoot);
-
-                        tree->releaseNode(nodeCa);
-                        computeAttributeOnTreeNode(tree, newRoot);
-                    }
-                } else if (finalUnionNode != nodeCa) {
-                    if (!tree->isRoot(finalUnionNode)) {
-                        this->disconnect(tree, finalUnionNode, false);
-                    }
-                    tree->attachNode(nodeCa, finalUnionNode);
-                    computeAttributeOnTreeNode(tree, nodeCa);
-                }
-            }
-
+            finalizeUpdateTreeAndContractRemovedNodes(dualTree, nodeCa, previousLevelUnionNode);
         }
 
 
     public:
         /**
-         * @brief Returns `true` iff this instantiation uses the dense altitude-bucket backend.
+         * @brief Returns `true` iff this instantiation uses the dense level backend.
          * @details Exposed mainly so tests and local benchmarks can report which backend is active.
+         * @return `true` when altitude buckets are stored in a compile-time dense
+         * array, `false` when an ordered sparse map is used instead.
          */
         static constexpr bool usesDenseLevelBackend() {
             return use_dense_levels;
         }
 
         /**
-         * @brief Returns the compile-time bit-width threshold used to enable the dense backend.
+         * @brief Returns the compile-time bit threshold used to enable the dense backend.
+         * @details Integral altitude domains whose effective bit width does not
+         * exceed this threshold use the dense bucket backend.
          */
         static constexpr int denseLevelBackendMaxBits() {
             return HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS;
         }
 
         /**
-         * @brief Creates an adjustment helper from paired dynamic min/max trees.
+         * @brief Creates the adjustment helper from a dynamic min-tree / max-tree pair.
          * @param mintree Dynamic min-tree.
          * @param maxtree Dynamic max-tree.
-         * @param graph Underlying graph shared by both hierarchies.
+         * @param graph Graph shared by both hierarchies.
+         * @pre `mintree`, `maxtree`, and `graph` must remain valid for the whole
+         * lifetime of this object.
+         * @pre Both trees must represent the same image domain and be consistent
+         * with the same adjacency graph.
          */
-        DualMinMaxTreeIncrementalFilter(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree), maxtree_(maxtree), graph_(&graph), mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)), removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
+        DualMinMaxTreeIncrementalFilter(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree),
+                                                                                                  maxtree_(maxtree),
+                                                                                                  graph_(&graph),
+                                                                                                  mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)),
+                                                                                                  removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)),
+                                                                                                  pixelsInCMarks_(std::max(mintree ? mintree->getNumTotalProperParts() : 0, maxtree ? maxtree->getNumTotalProperParts() : 0)),
+                                                                                                  climbedNodeMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
             hg_assert(mintree_ != nullptr, "mintree must not be null.");
             hg_assert(maxtree_ != nullptr, "maxtree must not be null.");
             hg_assert(graph_ != nullptr, "graph must not be null.");
@@ -829,12 +1104,14 @@ namespace hg::detail::hierarchy {
         virtual ~DualMinMaxTreeIncrementalFilter() = default;
 
         /**
-         * @brief Registers the incremental attribute computer and its two output buffers.
-         * @details Buffer sizing is the caller's responsibility. Each buffer must be
-         * indexable on the full global id space of its associated dynamic tree.
-         * @param computer Incremental attribute computer used after local edits.
-         * @param bufferMin Output buffer for min-tree attributes.
-         * @param bufferMax Output buffer for max-tree attributes.
+         * @brief Registers the incremental attribute computer and its output buffers.
+         * @details Buffer sizing and lifetime remain the caller responsibility.
+         * Each buffer must cover the global id space of the corresponding tree.
+         * Once configured, local structural edits performed by the incremental
+         * update refresh the touched node attributes through this computer.
+         * @param computer Incremental attribute computer shared by both trees.
+         * @param bufferMin Output buffer associated with the min-tree.
+         * @param bufferMax Output buffer associated with the max-tree.
          */
         void setAttributeComputer(const DynamicComponentTreeAttributeComputer<double> &computer, std::vector<double> &bufferMin, std::vector<double> &bufferMax) {
             attributeComputer_ = &computer;
@@ -843,18 +1120,30 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Registers external altitude arrays for the min-tree and max-tree.
+         * @brief Registers external altitude buffers for the min-tree and max-tree.
          * @details The adjustment logic reads node levels exclusively from these buffers.
-         * @param bufferMin Altitude buffer for the min-tree.
-         * @param bufferMax Altitude buffer for the max-tree.
+         * The buffers are not copied: the filter stores only raw pointers to
+         * their data and the corresponding sizes.
+         * @param bufferMin Altitude buffer associated with the min-tree.
+         * @param bufferMax Altitude buffer associated with the max-tree.
+         * @pre Both buffers must keep stable storage for the whole period in
+         * which the filter may query node altitudes.
          */
-        void setAltitudeBuffers(const std::vector<altitude_t> &bufferMin, const std::vector<altitude_t> &bufferMax) {
-            altitudeBufferMin_ = &bufferMin;
-            altitudeBufferMax_ = &bufferMax;
+        template<typename altitude_buffer_min_t, typename altitude_buffer_max_t>
+        void setAltitudeBuffers(const altitude_buffer_min_t &bufferMin, const altitude_buffer_max_t &bufferMax) {
+            altitudeBufferMinData_ = bufferMin.data();
+            altitudeBufferMaxData_ = bufferMax.data();
+            altitudeBufferMinSize_ = bufferMin.size();
+            altitudeBufferMaxSize_ = bufferMax.size();
         }
     
         /**
-         * @brief Prunes rooted subtrees from the max-tree and updates the min-tree after each valid prune.
+         * @brief Prunes rooted subtrees from the max-tree and updates the min-tree.
+         * @details Each valid entry of `nodesToPrune` is processed independently.
+         * Invalid ids, dead nodes, and the current root of the max-tree are
+         * ignored. For each remaining node, the min-tree is updated first and
+         * the corresponding subtree is then pruned from the max-tree.
+         * @param nodesToPrune Root ids of max-tree subtrees to be pruned.
          */
         void pruneMaxTreeAndUpdateMinTree(const std::vector<index_t> &nodesToPrune) {
             hg_assert(mintree_ != nullptr, "pruneMaxTreeAndUpdateMinTree: mintree must not be null.");
@@ -869,7 +1158,12 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Prunes rooted subtrees from the min-tree and updates the max-tree after each valid prune.
+         * @brief Prunes rooted subtrees from the min-tree and updates the max-tree.
+         * @details Each valid entry of `nodesToPrune` is processed independently.
+         * Invalid ids, dead nodes, and the current root of the min-tree are
+         * ignored. For each remaining node, the max-tree is updated first and
+         * the corresponding subtree is then pruned from the min-tree.
+         * @param nodesToPrune Root ids of min-tree subtrees to be pruned.
          */
         void pruneMinTreeAndUpdateMaxTree(const std::vector<index_t> &nodesToPrune) {
             hg_assert(mintree_ != nullptr, "pruneMinTreeAndUpdateMaxTree: mintree must not be null.");
@@ -887,8 +1181,8 @@ namespace hg::detail::hierarchy {
     namespace testing {
         struct DualMinMaxTreeIncrementalFilterTestAccess {
             template<typename altitude_t, typename graph_t>
-            static void updateTree(DualMinMaxTreeIncrementalFilter<altitude_t, graph_t> &adjust, DynamicComponentTree *tree, index_t rootIdSubtree) {
-                adjust.updateTree(tree, rootIdSubtree);
+            static void updateTree(DualMinMaxTreeIncrementalFilter<altitude_t, graph_t> &adjust, DynamicComponentTree *tree, index_t subtreeRoot) {
+                adjust.updateTree(tree, subtreeRoot);
             }
         };
     }

--- a/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
+++ b/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
@@ -24,12 +24,16 @@
 #include "higra/detail/hierarchy/dynamic_component_tree.hpp"
 #include "higra/utils.hpp"
 
+#ifndef HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS
+#define HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS 8
+#endif
+
 namespace hg::detail::hierarchy {
 
     namespace testing {
         // Test-only gateway used to keep the primitive update step private in production code
         // while preserving direct coverage of the core adjustment routine in unit tests.
-        struct ComponentTreeAdjustmentTestAccess;
+        struct DualMinMaxTreeIncrementalFilterTestAccess;
     }
 
     /**
@@ -61,7 +65,8 @@ namespace hg::detail::hierarchy {
      *    complementary hierarchy.
      *
      * Backend selection for `mergeNodesByLevel`:
-     *  - dense array-based buckets for small integral altitude domains (8 bits),
+     *  - dense array-based buckets for small integral altitude domains
+     *    (up to `HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS` bits),
      *    using an order-preserving dense index for signed types;
      *  - sparse ordered-map buckets for larger integral domains and floating-point altitudes.
      *
@@ -83,12 +88,12 @@ namespace hg::detail::hierarchy {
      * rebuild." Journal of Mathematical Imaging and Vision, 2026.
      */
     template<typename altitude_t, typename graph_t>
-    class ComponentTreeAdjustment {
+    class DualMinMaxTreeIncrementalFilter {
     private:
         using tree_t = DynamicComponentTree;
         // Friend access is restricted to the test helper so wrappers remain the only
         // production entry points while unit tests can still exercise updateTree directly.
-        friend struct testing::ComponentTreeAdjustmentTestAccess;
+        friend struct testing::DualMinMaxTreeIncrementalFilterTestAccess;
 
         /**
          * @brief O(1)-reset mark set based on generation stamps.
@@ -160,7 +165,7 @@ namespace hg::detail::hierarchy {
             if constexpr (std::is_integral_v<altitude_t>) {
                 // Only integral altitude types have a finite bit-width usable for dense buckets.
                 using unsigned_altitude_t = std::make_unsigned_t<altitude_t>;
-                return std::numeric_limits<unsigned_altitude_t>::digits <= 8;
+                return std::numeric_limits<unsigned_altitude_t>::digits <= HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS;
             } else {
                 return false;
             }
@@ -597,7 +602,7 @@ namespace hg::detail::hierarchy {
          * 4. merges nodes level by level;
          * 5. reconnects the final union node in the updated hierarchy.
          *
-         * Test-only access is provided through `testing::ComponentTreeAdjustmentTestAccess`.
+         * Test-only access is provided through `testing::DualMinMaxTreeIncrementalFilterTestAccess`.
          *
          * @param tree Target hierarchy updated in place.
          * @param rootIdSubtree Root node of the subtree already removed in the complementary hierarchy.
@@ -792,12 +797,27 @@ namespace hg::detail::hierarchy {
 
     public:
         /**
+         * @brief Returns `true` iff this instantiation uses the dense altitude-bucket backend.
+         * @details Exposed mainly so tests and local benchmarks can report which backend is active.
+         */
+        static constexpr bool usesDenseLevelBackend() {
+            return use_dense_levels;
+        }
+
+        /**
+         * @brief Returns the compile-time bit-width threshold used to enable the dense backend.
+         */
+        static constexpr int denseLevelBackendMaxBits() {
+            return HG_COMPONENT_TREE_ADJUSTMENT_DENSE_MAX_BITS;
+        }
+
+        /**
          * @brief Creates an adjustment helper from paired dynamic min/max trees.
          * @param mintree Dynamic min-tree.
          * @param maxtree Dynamic max-tree.
          * @param graph Underlying graph shared by both hierarchies.
          */
-        ComponentTreeAdjustment(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree), maxtree_(maxtree), graph_(&graph), mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)), removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
+        DualMinMaxTreeIncrementalFilter(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree), maxtree_(maxtree), graph_(&graph), mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)), removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
             hg_assert(mintree_ != nullptr, "mintree must not be null.");
             hg_assert(maxtree_ != nullptr, "maxtree must not be null.");
             hg_assert(graph_ != nullptr, "graph must not be null.");
@@ -806,7 +826,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Defaulted destructor.
          */
-        virtual ~ComponentTreeAdjustment() = default;
+        virtual ~DualMinMaxTreeIncrementalFilter() = default;
 
         /**
          * @brief Registers the incremental attribute computer and its two output buffers.
@@ -865,9 +885,9 @@ namespace hg::detail::hierarchy {
     };
 
     namespace testing {
-        struct ComponentTreeAdjustmentTestAccess {
+        struct DualMinMaxTreeIncrementalFilterTestAccess {
             template<typename altitude_t, typename graph_t>
-            static void updateTree(ComponentTreeAdjustment<altitude_t, graph_t> &adjust, DynamicComponentTree *tree, index_t rootIdSubtree) {
+            static void updateTree(DualMinMaxTreeIncrementalFilter<altitude_t, graph_t> &adjust, DynamicComponentTree *tree, index_t rootIdSubtree) {
                 adjust.updateTree(tree, rootIdSubtree);
             }
         };

--- a/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
+++ b/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
@@ -162,6 +162,15 @@ namespace hg::detail::hierarchy {
             }
 
             /**
+             * @brief Removes one mark from the current generation.
+             */
+            void unmark(size_t idx) noexcept {
+                if (stamp[idx] == cur) {
+                    stamp[idx] = 0;
+                }
+            }
+
+            /**
              * @brief Clears the set in O(1) amortized time.
              * @details The method advances the active generation. If the
              * generation counter overflows, the underlying storage is physically
@@ -415,12 +424,15 @@ namespace hg::detail::hierarchy {
         GenerationStampSet removedMarks_;
         GenerationStampSet pixelsInCMarks_;
         GenerationStampSet climbedNodeMarks_;
+        GenerationStampSet attributeUpdateMarks_;
         std::vector<index_t> properPartSetC_;
         std::vector<index_t> nodesPendingRemoval_;
         std::vector<index_t> removedNodesPendingAbsorption_;
+        altitude_t altitudeCa_ = altitude_t{};
 
         // Incremental attribute computation and external altitude buffers.
-        const DynamicComponentTreeAttributeComputer<double> *attributeComputer_ = nullptr;
+        const DynamicComponentTreeAttributeComputer<double> *attributeComputerMin_ = nullptr;
+        const DynamicComponentTreeAttributeComputer<double> *attributeComputerMax_ = nullptr;
         std::vector<double> *attributeBufferMin_ = nullptr;
         std::vector<double> *attributeBufferMax_ = nullptr;
         const altitude_t *altitudeBufferMinData_ = nullptr;
@@ -443,6 +455,9 @@ namespace hg::detail::hierarchy {
                 return;
             }
             tree->removeChild(parentId, nodeId, releaseNode);
+            if (releaseNode) {
+                notifyNodeRemoved(tree, nodeId);
+            }
         }
 
         /**
@@ -450,10 +465,53 @@ namespace hg::detail::hierarchy {
          * @return `nullptr` when no incremental attribute computer is configured.
          */
         std::vector<double> *getAttributeBuffer(tree_t *tree) const {
-            if (attributeComputer_ == nullptr) {
+            const auto *computer = tree == maxtree_ ? attributeComputerMax_ : attributeComputerMin_;
+            if (computer == nullptr) {
                 return nullptr;
             }
             return tree == maxtree_ ? attributeBufferMax_ : attributeBufferMin_;
+        }
+
+        /**
+         * @brief Returns the attribute computer associated with one tree.
+         */
+        const DynamicComponentTreeAttributeComputer<double> *getAttributeComputer(tree_t *tree) const {
+            if (tree == nullptr) {
+                return nullptr;
+            }
+            return tree == maxtree_ ? attributeComputerMax_ : attributeComputerMin_;
+        }
+
+        /**
+         * @brief Forwards a node-removal event to the incremental attribute computer of `tree`.
+         * @details The notification is skipped when no computer is configured or when the
+         * removed node id is invalid.
+         */
+        void notifyNodeRemoved(tree_t *tree, index_t nodeId) const {
+            const auto *computer = getAttributeComputer(tree);
+            if (computer != nullptr && tree != nullptr && nodeId != invalid_index) {
+                computer->onNodeRemoved(nodeId, *tree);
+            }
+        }
+
+        /**
+         * @brief Forwards a bulk proper-part transfer to the incremental attribute computer of `tree`.
+         */
+        void notifyMoveProperParts(tree_t *tree, index_t targetNodeId, index_t sourceNodeId) const {
+            const auto *computer = getAttributeComputer(tree);
+            if (computer != nullptr && tree != nullptr) {
+                computer->onMoveProperParts(targetNodeId, sourceNodeId, *tree);
+            }
+        }
+
+        /**
+         * @brief Forwards a single proper-part transfer to the incremental attribute computer of `tree`.
+         */
+        void notifyMoveProperPart(tree_t *tree, index_t targetNodeId, index_t sourceNodeId, index_t pixelId) const {
+            const auto *computer = getAttributeComputer(tree);
+            if (computer != nullptr && tree != nullptr) {
+                computer->onMoveProperPart(targetNodeId, sourceNodeId, pixelId, *tree);
+            }
         }
 
         /**
@@ -495,12 +553,44 @@ namespace hg::detail::hierarchy {
          * updates the buffer associated with the edited tree in place.
          */
         void computeAttributeOnTreeNode(tree_t *tree, index_t nodeId) {
-            if (attributeComputer_ == nullptr || tree == nullptr || nodeId == invalid_index || !tree->isAlive(nodeId)) {
+            const auto *computer = getAttributeComputer(tree);
+            if (computer == nullptr || tree == nullptr || nodeId == invalid_index ||
+                !tree->isNode(nodeId) || !tree->isAlive(nodeId)) {
                 return;
             }
             auto *buffer = getAttributeBuffer(tree);
             hg_assert(buffer != nullptr, "Attribute computer configured without a valid buffer.");
-            attributeComputer_->computeAttributeOnNode(*tree, nodeId, *buffer);
+            if (!attributeUpdateMarks_.isMarked((std::size_t) nodeId)) {
+                return;
+            }
+            const auto level = nodeAltitude(tree, nodeId);
+            if ((tree == maxtree_ && level < altitudeCa_) || (tree == mintree_ && level > altitudeCa_)) {
+                attributeUpdateMarks_.unmark((std::size_t) nodeId);
+                return;
+            }
+            computer->computeAttributeOnNode(*tree, nodeId, *buffer);
+            attributeUpdateMarks_.unmark((std::size_t) nodeId);
+        }
+
+        /**
+         * @brief Clears pending attribute-update marks for the current step.
+         */
+        void resetAttributeUpdateMarks() {
+            attributeUpdateMarks_.resetAll();
+            altitudeCa_ = altitude_t{};
+        }
+
+        /**
+         * @brief Marks one live node whose attribute must be recomputed.
+         */
+        void markAttributeUpdate(tree_t *tree, index_t nodeId) {
+            if (getAttributeComputer(tree) == nullptr || tree == nullptr || nodeId == invalid_index) {
+                return;
+            }
+            if (!tree->isNode(nodeId) || !tree->isAlive(nodeId)) {
+                return;
+            }
+            attributeUpdateMarks_.mark((std::size_t) nodeId);
         }
 
         /**
@@ -515,6 +605,7 @@ namespace hg::detail::hierarchy {
                     continue;
                 }
 
+                notifyMoveProperPart(dualTree, unionNode, ownerId, pixelId);
                 dualTree->moveProperPart(unionNode, ownerId, pixelId);
 
                 if (dualTree->isAlive(ownerId) && dualTree->getNumProperParts(ownerId) == 0 && ownerId != unionNode && !removedMarks_.isMarked(ownerId)) {
@@ -548,9 +639,14 @@ namespace hg::detail::hierarchy {
                 return invalid_index;
             }
 
+            const bool parentChanged = dualTree->getFirstChild(removedNodeId) != invalid_index;
             dualTree->moveChildren(parentId, removedNodeId);
+            notifyMoveProperParts(dualTree, parentId, removedNodeId);
             dualTree->moveProperParts(parentId, removedNodeId);
             disconnect(dualTree, removedNodeId, true);
+            if (parentChanged) {
+                markAttributeUpdate(dualTree, parentId);
+            }
             computeAttributeOnTreeNode(dualTree, parentId);
 
             if (dualTree->isAlive(parentId) && dualTree->getNumProperParts(parentId) == 0) {
@@ -581,17 +677,23 @@ namespace hg::detail::hierarchy {
                 }
             }
 
+            bool rootChanged = false;
             for (auto childId = firstChild; childId != invalid_index;) {
                 const index_t next = dualTree->getNextSibling(childId);
                 if (childId != newRoot && !dualTree->hasChild(newRoot, childId)) {
                     dualTree->detachNode(childId);
                     dualTree->attachNode(newRoot, childId);
+                    rootChanged = true;
                 }
                 childId = next;
             }
 
             dualTree->setRoot(newRoot);
             dualTree->releaseNode(removedNodeId);
+            notifyNodeRemoved(dualTree, removedNodeId);
+            if (rootChanged) {
+                markAttributeUpdate(dualTree, newRoot);
+            }
             computeAttributeOnTreeNode(dualTree, newRoot);
         }
 
@@ -692,6 +794,7 @@ namespace hg::detail::hierarchy {
                 }
 
                 disconnect(dualTree, current, true);
+                markAttributeUpdate(dualTree, promoted);
                 computeAttributeOnTreeNode(dualTree, promoted);
                 current = promoted;
             }
@@ -718,6 +821,7 @@ namespace hg::detail::hierarchy {
                     // topological position in the updated hierarchy.
                     if (!dualTree->isRoot(nodeCa)) {
                         const index_t nodeCaParentId = dualTree->getNodeParent(nodeCa);
+                        bool finalUnionNodeChanged = false;
 
                         if (!dualTree->isRoot(finalUnionNode)) {
                             this->disconnect(dualTree, finalUnionNode, false);
@@ -731,11 +835,16 @@ namespace hg::detail::hierarchy {
                                     this->disconnect(dualTree, childId, false);
                                 }
                                 dualTree->attachNode(finalUnionNode, childId);
+                                finalUnionNodeChanged = true;
                             }
                             childId = next;
                         }
 
                         this->disconnect(dualTree, nodeCa, true);
+                        if (finalUnionNodeChanged) {
+                            markAttributeUpdate(dualTree, finalUnionNode);
+                        }
+                        markAttributeUpdate(dualTree, nodeCaParentId);
                         computeAttributeOnTreeNode(dualTree, finalUnionNode);
                         computeAttributeOnTreeNode(dualTree, nodeCaParentId);
                     } else {
@@ -761,11 +870,13 @@ namespace hg::detail::hierarchy {
                             }
                         }
 
+                        bool candidateRootChanged = false;
                         if (candidateRootId != survivingFinalUnionNode) {
                             if (!dualTree->isRoot(survivingFinalUnionNode)) {
                                 this->disconnect(dualTree, survivingFinalUnionNode, false);
                             }
                             dualTree->attachNode(candidateRootId, survivingFinalUnionNode);
+                            candidateRootChanged = true;
                         }
 
                         for (auto childId = dualTree->getFirstChild(nodeCa); childId != invalid_index;) {
@@ -775,12 +886,16 @@ namespace hg::detail::hierarchy {
                                     this->disconnect(dualTree, childId, false);
                                 }
                                 dualTree->attachNode(candidateRootId, childId);
+                                candidateRootChanged = true;
                             }
                             childId = next;
                         }
 
                         dualTree->setRoot(candidateRootId);
                         dualTree->releaseNode(nodeCa);
+                        if (candidateRootChanged) {
+                            markAttributeUpdate(dualTree, candidateRootId);
+                        }
                         computeAttributeOnTreeNode(dualTree, candidateRootId);
                     }
                 } else {
@@ -789,6 +904,7 @@ namespace hg::detail::hierarchy {
                         this->disconnect(dualTree, finalUnionNode, false);
                     }
                     dualTree->attachNode(nodeCa, finalUnionNode);
+                    markAttributeUpdate(dualTree, nodeCa);
                     computeAttributeOnTreeNode(dualTree, nodeCa);
                 }
             }
@@ -912,6 +1028,7 @@ namespace hg::detail::hierarchy {
         void updateTree(tree_t *dualTree, index_t subtreeRoot) {
             hg_assert(dualTree != nullptr, "updateTree: dualTree must not be null.");
             hg_assert(subtreeRoot != invalid_index, "updateTree: subtreeRoot is invalid.");
+            resetAttributeUpdateMarks();
 
             const bool isMaxtree = dualTree == maxtree_;
             tree_t *primalTree = getPrimalTree(isMaxtree);
@@ -925,7 +1042,7 @@ namespace hg::detail::hierarchy {
             const altitude_t b = nodeAltitude(primalTree, subtreeParentId);
 
             index_t nodeCa = invalid_index;
-            altitude_t altitudeCa = altitude_t{};
+            altitudeCa_ = altitude_t{};
 
             // Phase 1: collect the set `C` in the primal tree and locate `nodeCa`
             // as the extreme representative of `C` in the updated tree.
@@ -942,8 +1059,8 @@ namespace hg::detail::hierarchy {
                         continue; // Proper parts without a live dual component do not contribute to `nodeCa`.
                     }
                     const altitude_t altitudeP = nodeAltitude(dualTree, nodeP);
-                    if (nodeCa == invalid_index || ((isMaxtree && altitudeP < altitudeCa) || (!isMaxtree && altitudeP > altitudeCa))) {
-                        altitudeCa = altitudeP;
+                    if (nodeCa == invalid_index || ((isMaxtree && altitudeP < altitudeCa_) || (!isMaxtree && altitudeP > altitudeCa_))) {
+                        altitudeCa_ = altitudeP;
                         nodeCa = nodeP;
                     }
                 }
@@ -953,7 +1070,7 @@ namespace hg::detail::hierarchy {
             }
             hg_assert(nodeCa != invalid_index, "updateTree: invalid C_a representative.");
             hg_assert(!properPartSetC_.empty(), "updateTree: expected non-empty proper parts in removed subtree.");
-
+            
             
             const auto *targetAltitude = getAltitudeBufferData(dualTree);
             hg_assert(targetAltitude != nullptr, "updateTree: altitude buffer must be configured for target tree.");
@@ -969,7 +1086,7 @@ namespace hg::detail::hierarchy {
             removedMarks_.resetAll();
             removedNodesPendingAbsorption_.clear();
             nodesPendingRemoval_.reserve(mergeNodesByLevel_.getMaxBucketSize());
-            while (mergeNodesByLevel_.hasMergeLevel() && ((isMaxtree && currentMergeLevel > altitudeCa) || (!isMaxtree && currentMergeLevel < altitudeCa))) {
+            while (mergeNodesByLevel_.hasMergeLevel() && ((isMaxtree && currentMergeLevel > altitudeCa_) || (!isMaxtree && currentMergeLevel < altitudeCa_))) {
                 auto &nodesAtCurrentLevel = mergeNodesByLevel_.getMergedNodes(currentMergeLevel);
                 currentUnionNode = invalid_index;
                 nodesPendingRemoval_.clear();
@@ -996,6 +1113,7 @@ namespace hg::detail::hierarchy {
                         // the first effective union node that survives the sweep.
                         for (auto pendingNodeId: nodesPendingRemoval_) {
                             this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, pendingNodeId);
+                            notifyMoveProperParts(dualTree, currentUnionNode, pendingNodeId);
                             dualTree->moveProperParts(currentUnionNode, pendingNodeId);
                             this->disconnect(dualTree, pendingNodeId, true);
                         }
@@ -1004,6 +1122,7 @@ namespace hg::detail::hierarchy {
                     }
 
                     this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, nodeId);
+                    notifyMoveProperParts(dualTree, currentUnionNode, nodeId);
                     dualTree->moveProperParts(currentUnionNode, nodeId);
                     this->disconnect(dualTree, nodeId, true);
                 }
@@ -1017,6 +1136,7 @@ namespace hg::detail::hierarchy {
                         }
                         const auto parentId = dualTree->getNodeParent(nodeId);
                         dualTree->moveChildren(parentId, nodeId);
+                        notifyMoveProperParts(dualTree, parentId, nodeId);
                         dualTree->moveProperParts(parentId, nodeId);
                         this->disconnect(dualTree, nodeId, true);
                     }
@@ -1046,6 +1166,7 @@ namespace hg::detail::hierarchy {
                     }
                 }
 
+                markAttributeUpdate(dualTree, currentUnionNode);
                 computeAttributeOnTreeNode(dualTree, currentUnionNode);
 
                 previousLevelUnionNode = currentUnionNode;
@@ -1092,7 +1213,8 @@ namespace hg::detail::hierarchy {
                                                                                                   mergeNodesByLevel_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)),
                                                                                                   removedMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)),
                                                                                                   pixelsInCMarks_(std::max(mintree ? mintree->getNumTotalProperParts() : 0, maxtree ? maxtree->getNumTotalProperParts() : 0)),
-                                                                                                  climbedNodeMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
+                                                                                                  climbedNodeMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)),
+                                                                                                  attributeUpdateMarks_(std::max(mintree ? mintree->getGlobalIdSpaceSize() : 0, maxtree ? maxtree->getGlobalIdSpaceSize() : 0)) {
             hg_assert(mintree_ != nullptr, "mintree must not be null.");
             hg_assert(maxtree_ != nullptr, "maxtree must not be null.");
             hg_assert(graph_ != nullptr, "graph must not be null.");
@@ -1109,14 +1231,25 @@ namespace hg::detail::hierarchy {
          * Each buffer must cover the global id space of the corresponding tree.
          * Once configured, local structural edits performed by the incremental
          * update refresh the touched node attributes through this computer.
-         * @param computer Incremental attribute computer shared by both trees.
+         * @param computerMin Incremental attribute computer associated with the min-tree.
+         * @param computerMax Incremental attribute computer associated with the max-tree.
          * @param bufferMin Output buffer associated with the min-tree.
          * @param bufferMax Output buffer associated with the max-tree.
          */
-        void setAttributeComputer(const DynamicComponentTreeAttributeComputer<double> &computer, std::vector<double> &bufferMin, std::vector<double> &bufferMax) {
-            attributeComputer_ = &computer;
+        void setAttributeComputer(const DynamicComponentTreeAttributeComputer<double> &computerMin,
+                                  const DynamicComponentTreeAttributeComputer<double> &computerMax,
+                                  std::vector<double> &bufferMin,
+                                  std::vector<double> &bufferMax) {
+            attributeComputerMin_ = &computerMin;
+            attributeComputerMax_ = &computerMax;
             attributeBufferMin_ = &bufferMin;
             attributeBufferMax_ = &bufferMax;
+        }
+
+        void setAttributeComputer(const DynamicComponentTreeAttributeComputer<double> &computer,
+                                  std::vector<double> &bufferMin,
+                                  std::vector<double> &bufferMax) {
+            setAttributeComputer(computer, computer, bufferMin, bufferMax);
         }
 
         /**

--- a/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
+++ b/include/higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp
@@ -37,7 +37,7 @@ namespace hg::detail::hierarchy {
     }
 
     /**
-     * @brief Incremental updater for paired dynamic min-tree / max-tree hierarchies.
+     * @brief Incremental updater for paired dynamic min-tree and max-tree hierarchies.
      * 
      * This class implements the update-rather-than-rebuild strategy introduced
      * in [1,2] and used for efficient connected alternating sequential filters.
@@ -47,13 +47,13 @@ namespace hg::detail::hierarchy {
      *
      * More precisely, when a rooted subtree is removed from one hierarchy, this
      * helper updates the dual hierarchy in place so that both trees remain
-     * consistent with the same filtered image. The update is performed by
-     * collecting valid adjacent seeds around the induced proper-part set `C`,
+     * consistent with the same filtered vertex weights. The update is performed by
+     * collecting valid adjacent candidate nodes around the induced proper-part set `C`,
      * climbing each relevant ancestor chain once, and merging nodes level by
      * level instead of rebuilding the whole dual tree from scratch.
      *
      * Public usage model:
-     *  - construct the helper from a dynamic min-tree / max-tree pair and the
+     *  - construct the helper from a dynamic min-tree and max-tree pair and the
      *    shared adjacency graph;
      *  - optionally register an incremental attribute computer and the
      *    attribute buffers to be refreshed after local edits;
@@ -185,7 +185,7 @@ namespace hg::detail::hierarchy {
         };
 
         /**
-         * @brief Returns `true` iff the altitude type should use dense buckets.
+         * @brief Returns `true` if and only if the altitude type should use dense buckets.
          * @details Dense buckets are enabled only for small integral altitude
          * domains. Larger integral domains and floating-point types use the
          * sparse backend.
@@ -201,7 +201,7 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief True iff `mergeNodesByLevel` uses the dense bucket backend.
+         * @brief `true` if and only if `mergeNodesByLevel` uses the dense bucket backend.
          */
         static constexpr bool use_dense_levels = usesDenseLevels();
 
@@ -302,7 +302,7 @@ namespace hg::detail::hierarchy {
             /**
              * @brief Returns the frontier roots collected above `b`.
              * @details Each stored node is the root of the first branch that
-             * leaves the merge interval while climbing from a valid adjacent seed.
+             * leaves the merge interval while climbing from a valid adjacent candidate node.
              */
             std::vector<index_t> &getFrontierNodesAboveB() {
                 return frontierNodesAboveB_;
@@ -317,8 +317,8 @@ namespace hg::detail::hierarchy {
             }
 
             /**
-             * @brief Marks one adjacent seed at most once in the current step.
-             * @return `true` if the seed was accepted now, `false` if it had already been seen.
+             * @brief Marks one adjacent candidate node at most once in the current step.
+             * @return `true` if the candidate was accepted now, `false` if it had already been seen.
              */
             bool markAdjacentSeed(index_t nodeId) {
                 if (adjacentSeedMarks_.isMarked(nodeId)) {
@@ -594,7 +594,7 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Moves the removed proper-part set onto the current union node.
+         * @brief Moves the removed proper-part set onto the current merged node.
          * @details Any node left without direct proper parts is marked in
          * `removedMarks_` so it can be contracted later in the step.
          */
@@ -701,7 +701,7 @@ namespace hg::detail::hierarchy {
          * @brief Contracts, in post-order, nodes that remained alive but empty.
          * @details This pass runs after the level sweep, when the local topology
          * is already stable. The explicit stack visits only nodes that are still
-         * marked and still empty, skipping obsolete seeds.
+         * marked and still empty, skipping obsolete entries.
          */
         void absorbRemovedNodes(tree_t *dualTree, const std::vector<index_t> &removedNodeIds) {
             struct Frame {
@@ -804,7 +804,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Finalizes the reconnection between `nodeCa`, `finalUnionNode`, and removed nodes.
-         * @details First resolves the final topological position of the union node
+         * @details First resolves the final topological position of the merged node
          * produced by the level sweep. Then contracts, in post-order, the nodes
          * that remained alive but empty until the end of the step.
          */
@@ -817,7 +817,7 @@ namespace hg::detail::hierarchy {
 
             if (finalUnionNode != invalid_index && dualTree->isAlive(finalUnionNode)) {
                 if (removedMarks_.isMarked(nodeCa)) {
-                    // If `nodeCa` was emptied, the final union node must occupy its
+                    // If `nodeCa` was emptied, the final merged node must occupy its
                     // topological position in the updated hierarchy.
                     if (!dualTree->isRoot(nodeCa)) {
                         const index_t nodeCaParentId = dualTree->getNodeParent(nodeCa);
@@ -899,7 +899,7 @@ namespace hg::detail::hierarchy {
                         computeAttributeOnTreeNode(dualTree, candidateRootId);
                     }
                 } else {
-                    // If `nodeCa` survived, the final union node becomes its child.
+                    // If `nodeCa` survived, the final merged node becomes its child.
                     if (!dualTree->isRoot(finalUnionNode)) {
                         this->disconnect(dualTree, finalUnionNode, false);
                     }
@@ -913,15 +913,16 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Returns the primal hierarchy for one update direction.
+         * @brief Returns the primal tree for one update direction.
          */
         tree_t *getPrimalTree(bool isMaxtree) {
             return isMaxtree ? mintree_ : maxtree_;
         }
 
         /**
-         * @brief Reattaches under `targetNodeId` only the direct children of `sourceNodeId` outside `Γ[a,b]`.
-         * @details Children still marked as belonging to the merge interval are
+         * @brief Reattaches selected direct children of `sourceNodeId` under `targetNodeId`.
+         * @details Only children outside the merge interval `[a, b]` are reattached.
+         * Children still marked as belonging to the merge interval are
          * detached and left isolated until their own sweep level is processed.
          */
         void reattachOutsideIntervalChildren(tree_t *tree, index_t targetNodeId, index_t sourceNodeId) {
@@ -951,7 +952,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Builds `mergeNodesByLevel_` and `frontierNodesAboveB_` for one adjustment step.
          * @details The method scans graph neighbors of the proper-part set `C`,
-         * filters valid adjacent seeds, and climbs each relevant ancestor chain
+         * filters valid adjacent candidate nodes, and climbs each relevant ancestor chain
          * at most once. Each visited node is inserted either in the bucket of its
          * own level or, when above `b`, in `frontierNodesAboveB_`.
          */
@@ -961,23 +962,23 @@ namespace hg::detail::hierarchy {
             climbedNodeMarks_.resetAll();
             const altitude_t altitudeCa = altitude[nodeCa];
 
-            // For each proper part of `C`, collect valid adjacent seeds and climb
+            // For each proper part of `C`, collect valid adjacent candidate nodes and climb
             // only once through each relevant ancestor chain.
             for (auto p: properPartSetC) {
                 for (auto q: adjacent_vertex_iterator(p, *graph_)) {
                     if (pixelsInCMarks_.isMarked(q)) {
-                        continue; // Neighbors internal to `C` do not generate adjacent seeds.
+                        continue; // Neighbors internal to `C` do not generate adjacent candidates.
                     }
 
                     const index_t nodeQ = tree.getSmallestComponent(q);
                     if (nodeQ == invalid_index) {
-                        continue; // Pixels without a live component do not enter the collection.
+                        continue; // Proper parts without a live component do not enter the collection.
                     }
 
                     const altitude_t altitudeQ = altitude[nodeQ];
                     const bool validSeed = (isMaxtree && altitudeQ >= altitudeCa) || (!isMaxtree && altitudeQ <= altitudeCa);
                     if (!validSeed) {
-                        continue; // Seeds outside the valid interval do not participate in the merge.
+                        continue; // Candidates outside the valid interval do not participate in the merge.
                     }
 
                     if (mergeNodesByLevel_.markAdjacentSeed(nodeQ)) {
@@ -1006,7 +1007,7 @@ namespace hg::detail::hierarchy {
 
                             const auto parentId = tree.getNodeParent(n);
                             if (parentId == n) {
-                                break; // Reached the structural top of this path.
+                                break; // Reached the root of the current ancestor path.
                             }
                             n = parentId;
                         }
@@ -1023,7 +1024,7 @@ namespace hg::detail::hierarchy {
          * 2. finds the representative of `C_a^-` and the altitude interval to sweep;
          * 3. builds the merge collections;
          * 4. merges nodes level by level;
-         * 5. reconnects the final union node in the updated hierarchy.
+         * 5. reconnects the final merged node in the updated hierarchy.
          */
         void updateTree(tree_t *dualTree, index_t subtreeRoot) {
             hg_assert(dualTree != nullptr, "updateTree: dualTree must not be null.");
@@ -1079,7 +1080,7 @@ namespace hg::detail::hierarchy {
             buildMergedAndNestedCollections(*dualTree, targetAltitude, properPartSetC_, nodeCa, b, isMaxtree);
 
             // Phase 3: sweep the active levels between `b` and `a`, merging the
-            // buckets and propagating the union node created at each level.
+            // buckets and propagating the merged node created at each level.
             altitude_t currentMergeLevel = mergeNodesByLevel_.firstMergeLevel();
             index_t currentUnionNode;
             index_t previousLevelUnionNode = invalid_index;
@@ -1100,17 +1101,17 @@ namespace hg::detail::hierarchy {
                         if (removedMarks_.isMarked(nodeId)) {
                             // If the first candidate at this level was already emptied
                             // when moving proper parts, keep it pending until an actual
-                            // union node appears at this level.
+                            // merged node appears at this level.
                             nodesPendingRemoval_.push_back(nodeId);
                             continue;
                         }
-                        // The first surviving node of the level becomes the current union node.
+                        // The first surviving node of the level becomes the current merged node.
                         currentUnionNode = nodeId;
                         this->disconnect(dualTree, currentUnionNode, false);
                         this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, currentUnionNode);
 
                         // Nodes that were already empty at this level are absorbed into
-                        // the first effective union node that survives the sweep.
+                        // the first effective merged node that survives the sweep.
                         for (auto pendingNodeId: nodesPendingRemoval_) {
                             this->reattachOutsideIntervalChildren(dualTree, currentUnionNode, pendingNodeId);
                             notifyMoveProperParts(dualTree, currentUnionNode, pendingNodeId);
@@ -1128,7 +1129,7 @@ namespace hg::detail::hierarchy {
                 }
 
                 if (currentUnionNode == invalid_index) {
-                    // If no union node survived at this level, finish collapsing the
+                    // If no merged node survived at this level, finish collapsing the
                     // pending empty nodes into their current parents and move on.
                     for (auto nodeId: nodesPendingRemoval_) {
                         if (!dualTree->isAlive(nodeId) || dualTree->isRoot(nodeId)) {
@@ -1147,7 +1148,7 @@ namespace hg::detail::hierarchy {
 
                 if (currentMergeLevel == b) {
                     // When the sweep reaches `b`, move the set `C` onto the current
-                    // union node and reconnect the frontier branches above `b`.
+                    // merged node and reconnect the frontier branches above `b`.
                     this->moveSelectedProperPartsToNode(dualTree, currentUnionNode, properPartSetC_);
                     for (auto nodeId: mergeNodesByLevel_.getFrontierNodesAboveB()) {
                         this->disconnect(dualTree, nodeId, false);
@@ -1156,8 +1157,8 @@ namespace hg::detail::hierarchy {
                 }
 
                 if (previousLevelUnionNode != invalid_index) {
-                    // The union node produced at the previous level becomes a child of
-                    // the current level union node when both still survive.
+                    // The merged node produced at the previous level becomes a child of
+                    // the current level merged node when both still survive.
                     if (dualTree->isAlive(previousLevelUnionNode) && !dualTree->hasChild(currentUnionNode, previousLevelUnionNode)) {
                         if (!dualTree->isRoot(previousLevelUnionNode)) {
                             this->disconnect(dualTree, previousLevelUnionNode, false);
@@ -1179,7 +1180,7 @@ namespace hg::detail::hierarchy {
 
     public:
         /**
-         * @brief Returns `true` iff this instantiation uses the dense level backend.
+         * @brief Returns `true` if and only if this instantiation uses the dense level backend.
          * @details Exposed mainly so tests and local benchmarks can report which backend is active.
          * @return `true` when altitude buckets are stored in a compile-time dense
          * array, `false` when an ordered sparse map is used instead.
@@ -1198,14 +1199,14 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Creates the adjustment helper from a dynamic min-tree / max-tree pair.
+         * @brief Creates the adjustment helper from a dynamic min-tree and max-tree pair.
          * @param mintree Dynamic min-tree.
          * @param maxtree Dynamic max-tree.
          * @param graph Graph shared by both hierarchies.
          * @pre `mintree`, `maxtree`, and `graph` must remain valid for the whole
          * lifetime of this object.
-         * @pre Both trees must represent the same image domain and be consistent
-         * with the same adjacency graph.
+         * @pre Both trees must represent the same input vertex set and be
+         * consistent with the same adjacency graph.
          */
         DualMinMaxTreeIncrementalFilter(tree_t *mintree, tree_t *maxtree, const graph_t &graph): mintree_(mintree),
                                                                                                   maxtree_(maxtree),

--- a/include/higra/detail/hierarchy/dynamic_component_tree.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree.hpp
@@ -1,0 +1,1527 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/structure/array.hpp"
+#include "higra/utils.hpp"
+
+namespace hg {
+
+    /**
+     * @brief Dynamic representation of a component tree with separated internal-node and proper-part storage.
+     *
+     * The structure stores:
+     *  - a mutable internal hierarchy restricted to internal nodes, and
+     *  - a distinct proper-part ownership structure for pixels/leaves.
+     *
+     * Notation used in this class:
+     *  - `N`: size of the global id space (`N = getGlobalIdSpaceSize()`).
+     *  - `L`: number of proper parts / pixels (`L = getNumTotalProperParts()`).
+     *  - `I`: number of node slots (`I = getNumInternalNodeSlots()`).
+     *  - `C_component_tree`: cost of building a component tree with Higra
+     *    (`component_tree_max_tree` or `component_tree_min_tree`), including sorting
+     *    and union-find/canonization steps.
+     *
+     * Node id conventions:
+     *  - Global id: id in `[0, N)`, addressing both proper parts and internal nodes.
+     *  - Local node-slot id: id in `[0, I)`, addressing only internal nodes.
+     *
+     * Mapping between both spaces:
+     *  - `globalNodeId = localNodeSlotId + L`
+     *  - `localNodeSlotId = globalNodeId - L`
+     *
+     * Internal nodes occupy the interval `[L, N)`, following Higra topological convention.
+     *
+     * Local-slot policy:
+     *  - mutable internal hierarchy arrays (`firstChild`, `lastChild`, `nextSibling`,
+     *    `prevSibling`, `numChildrenByNode`, `nodeParent`, `nodeAltitude`) are indexed by
+     *    and store local node-slot ids when applicable;
+     *  - proper-part ownership arrays are indexed by global proper-part ids `[0, L)`;
+     *  - public APIs still expose global ids to stay consistent with Higra conventions.
+     *
+     * Iterators/ranges provided by this class:
+     *  - `getAliveNodeIds()`: linear range over all alive internal global ids `[L, N)`.
+     *  - `getChildren(nodeId)`: direct internal children of `nodeId`.
+     *  - `getProperParts(nodeId)`: proper-part pixels directly owned by `nodeId`.
+     *  - `getPostOrderNodes()`, `getPostOrderNodes(rootNodeId)`:
+     *    internal hierarchy in post-order.
+     *  - `getBreadthFirstNodes()`, `getBreadthFirstNodes(rootNodeId)`:
+     *    internal hierarchy in breadth-first order.
+     *  - `getPathToRootNodes(nodeId)`: path from `nodeId` to root (both endpoints included).
+     *  - `getNodeSubtree(nodeId)`: internal nodes of the rooted subtree (pre-order, includes `nodeId`).
+     *  - `getDescendants(nodeId)`: descendants of `nodeId` (pre-order, excludes `nodeId`).
+     *
+     * Traversal ranges are lazy: creation is O(1); full iteration cost is linear in the
+     * number of returned elements.
+     *
+     * @tparam altitude_t Scalar altitude type.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree {
+    private:
+        // ---------------------------------------------------------------------
+        // Private attributes
+        // ---------------------------------------------------------------------
+
+        // Global counters.
+        index_t numTotalProperParts_ = 0;
+        index_t numInternalNodeSlots_ = 0;
+        index_t rootNodeId = invalid_index;
+
+        // Free internal-node slots, stored as local node-slot ids [0, I).
+        std::vector<index_t> freeNodeSlots;
+
+        // Internal-node arrays, indexed by local node-slot id [0, I).
+        // Values are global internal ids [L, N) or invalid_index when appropriate.
+        std::vector<index_t> nodeParent;
+        std::vector<altitude_t> nodeAltitude;
+
+        // Proper-part ownership, indexed by proper-part global id [0, L).
+        // Values are global internal ids [L, N).
+        std::vector<index_t> properPartOwner;
+
+        // Proper-parts linked lists, indexed by local node-slot id [0, I).
+        // Stored values are global proper-part ids [0, L).
+        std::vector<index_t> properHead;
+        std::vector<index_t> properTail;
+        std::vector<index_t> numProperPartsByNode;
+        std::vector<index_t> nextProperPart;
+        std::vector<index_t> prevProperPart;
+
+        // Internal hierarchy linked structure, indexed by local node-slot id [0, I).
+        // Stored values are local internal ids [0, I) or invalid_index.
+        std::vector<index_t> firstChild;
+        std::vector<index_t> lastChild;
+        std::vector<index_t> nextSibling;
+        std::vector<index_t> prevSibling;
+        std::vector<index_t> numChildrenByNode;
+
+        // Fail-fast iterator versions.
+        std::size_t nodeStructureVersion = 0;
+        std::size_t topologyVersion = 0;
+        std::size_t properPartVersion = 0;
+
+        // ---------------------------------------------------------------------
+        // Private methods
+        // ---------------------------------------------------------------------
+
+        /**
+         * @brief Appends a detached child at the back of a parent's child list.
+         * @warning Caller must ensure detached child and valid relation.
+         * @complexity Time O(1), Space O(1).
+         */
+        void linkChildBack(index_t parentId, index_t childId) {
+            const auto parentLocalId = localOf(parentId);
+            const auto childLocalId = localOf(childId);
+            const auto tail = lastChild[(size_t) parentLocalId];
+            if (tail == invalid_index) {
+                firstChild[(size_t) parentLocalId] = childLocalId;
+                lastChild[(size_t) parentLocalId] = childLocalId;
+            } else {
+                nextSibling[(size_t) tail] = childLocalId;
+                prevSibling[(size_t) childLocalId] = tail;
+                lastChild[(size_t) parentLocalId] = childLocalId;
+            }
+            numChildrenByNode[(size_t) parentLocalId]++;
+        }
+
+        /**
+         * @brief Unlinks an attached child from its parent child list.
+         * @warning Caller must ensure attached state and non-root use.
+         * @complexity Time O(1), Space O(1).
+         */
+        void unlinkChild(index_t childId) {
+            const auto childLocalId = localOf(childId);
+            const auto parentId = nodeParent[(size_t) childLocalId];
+            const auto parentLocalId = localOf(parentId);
+            const auto prev = prevSibling[(size_t) childLocalId];
+            const auto next = nextSibling[(size_t) childLocalId];
+
+            if (prev != invalid_index) {
+                nextSibling[(size_t) prev] = next;
+            } else {
+                firstChild[(size_t) parentLocalId] = next;
+            }
+
+            if (next != invalid_index) {
+                prevSibling[(size_t) next] = prev;
+            } else {
+                lastChild[(size_t) parentLocalId] = prev;
+            }
+
+            prevSibling[(size_t) childLocalId] = invalid_index;
+            nextSibling[(size_t) childLocalId] = invalid_index;
+            numChildrenByNode[(size_t) parentLocalId]--;
+        }
+
+        /**
+         * @brief Moves all proper parts owned by nodeB to nodeA.
+         * @warning This is a low-level helper that assumes both nodes are valid and alive.
+         * @complexity Time O(k), Space O(1), where k is the number of moved proper parts.
+         */
+        void moveProperPartsInBackend(index_t nodeA, index_t nodeB) {
+            const auto localA = localOf(nodeA);
+            const auto localB = localOf(nodeB);
+            if (numProperPartsByNode[(size_t) localB] == 0) {
+                return;
+            }
+
+            for (auto pixelId = properHead[(size_t) localB]; pixelId != invalid_index; pixelId = nextProperPart[(size_t) pixelId]) {
+                properPartOwner[(size_t) pixelId] = nodeA;
+            }
+
+            if (numProperPartsByNode[(size_t) localA] == 0) {
+                properHead[(size_t) localA] = properHead[(size_t) localB];
+                properTail[(size_t) localA] = properTail[(size_t) localB];
+                numProperPartsByNode[(size_t) localA] = numProperPartsByNode[(size_t) localB];
+            } else {
+                prevProperPart[(size_t) properHead[(size_t) localB]] = properTail[(size_t) localA];
+                nextProperPart[(size_t) properTail[(size_t) localA]] = properHead[(size_t) localB];
+                properTail[(size_t) localA] = properTail[(size_t) localB];
+                numProperPartsByNode[(size_t) localA] += numProperPartsByNode[(size_t) localB];
+            }
+
+            properHead[(size_t) localB] = invalid_index;
+            properTail[(size_t) localB] = invalid_index;
+            numProperPartsByNode[(size_t) localB] = 0;
+        }
+
+        /**
+         * @brief Detaches an internal node from its parent in the backend state.
+         * @complexity Time O(1), Space O(1).
+         */
+        void detachNodeInBackend(index_t nodeId) {
+            unlinkChild(nodeId);
+            const auto localId = localOf(nodeId);
+            nodeParent[(size_t) localId] = nodeId;
+        }
+
+        /**
+         * @brief Releases an internal node slot in the backend state.
+         * @warning Node must already be detached and contain no children/proper parts.
+         * @complexity Time O(1), Space O(1).
+         */
+        void releaseNodeSlot(index_t nodeId) {
+            const auto localId = localOf(nodeId);
+            firstChild[(size_t) localId] = invalid_index;
+            lastChild[(size_t) localId] = invalid_index;
+            nextSibling[(size_t) localId] = invalid_index;
+            prevSibling[(size_t) localId] = invalid_index;
+            numChildrenByNode[(size_t) localId] = 0;
+            properHead[(size_t) localId] = invalid_index;
+            properTail[(size_t) localId] = invalid_index;
+            numProperPartsByNode[(size_t) localId] = 0;
+            nodeParent[(size_t) localId] = invalid_index;
+            nodeAltitude[(size_t) localId] = altitude_t{};
+            freeNodeSlots.push_back(localId);
+        }
+
+        void checkNodeIteratorVersion(std::size_t expectedVersion) const {
+            #ifndef NDEBUG
+            hg_assert(expectedVersion == nodeStructureVersion,"Alive-node iterator invalidated by node-structure mutation.");
+            #else
+            (void) expectedVersion;
+            #endif
+        }
+
+        void checkTopologyIteratorVersion(std::size_t expectedVersion) const {
+            #ifndef NDEBUG
+            hg_assert(expectedVersion == topologyVersion,"Topology iterator invalidated by tree-structure mutation.");
+            #else
+            (void) expectedVersion;
+            #endif
+        }
+
+        void checkProperPartIteratorVersion(std::size_t expectedVersion) const {
+            #ifndef NDEBUG
+            hg_assert(expectedVersion == properPartVersion,"Proper-parts iterator invalidated by proper-part mutation.");
+            #else
+            (void) expectedVersion;
+            #endif
+        }
+
+        /**
+         * @brief Initializes storage for a dynamic tree with the given number of leaves and node slots.
+         * @complexity Time O(L + I), Space O(L + I).
+         */
+        void initializeStorage(index_t numProperParts, index_t numInternalNodeSlots) {
+            hg_assert(numProperParts > 0, "DynamicComponentTree must contain at least one proper part.");
+
+            numTotalProperParts_ = numProperParts;
+            numInternalNodeSlots_ = numInternalNodeSlots;
+            rootNodeId = invalid_index;
+
+            freeNodeSlots.clear();
+            nodeParent.resize((size_t) numInternalNodeSlots_);
+            nodeAltitude.resize((size_t) numInternalNodeSlots_);
+            properPartOwner.resize((size_t) numTotalProperParts_);
+
+            properHead.assign((size_t) numInternalNodeSlots_, invalid_index);
+            properTail.assign((size_t) numInternalNodeSlots_, invalid_index);
+            numProperPartsByNode.assign((size_t) numInternalNodeSlots_, 0);
+            nextProperPart.assign((size_t) numTotalProperParts_, invalid_index);
+            prevProperPart.assign((size_t) numTotalProperParts_, invalid_index);
+            firstChild.assign((size_t) numInternalNodeSlots_, invalid_index);
+            lastChild.assign((size_t) numInternalNodeSlots_, invalid_index);
+            nextSibling.assign((size_t) numInternalNodeSlots_, invalid_index);
+            prevSibling.assign((size_t) numInternalNodeSlots_, invalid_index);
+            numChildrenByNode.assign((size_t) numInternalNodeSlots_, 0);
+            nodeStructureVersion = 0;
+            topologyVersion = 0;
+            properPartVersion = 0;
+        }
+
+        /**
+         * @brief Builds the dynamic tree from Higra parent/altitude arrays.
+         * @complexity Time O(N), Space O(N).
+         */
+        template<typename T1, typename T2>
+        void buildFromParentAltitude(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
+            auto &sourceParent = xparent.derived_cast();
+            auto &sourceAltitude = xaltitude.derived_cast();
+
+            hg_assert_1d_array(sourceParent);
+            hg_assert_1d_array(sourceAltitude);
+            hg_assert_integral_value_type(sourceParent);
+            hg_assert_same_shape(sourceParent, sourceAltitude);
+
+            const auto parent = xt::cast<index_t>(sourceParent);
+            const auto altitude = xt::cast<altitude_t>(sourceAltitude);
+            const index_t n = (index_t) parent.size();
+
+            hg_assert(n > 0, "DynamicComponentTree cannot be empty.");
+            hg_assert(numProperParts > 0 && numProperParts < n, "Invalid number of proper parts.");
+
+            initializeStorage(numProperParts, n - numProperParts);
+            rootNodeId = n - 1;
+
+            for (index_t nodeId = numTotalProperParts_; nodeId < n; ++nodeId) {
+                const auto localId = localOf(nodeId);
+                nodeParent[(size_t) localId] = parent(nodeId);
+                nodeAltitude[(size_t) localId] = altitude(nodeId);
+                if (parent(nodeId) == invalid_index) {
+                    freeNodeSlots.push_back(localId);
+                }
+            }
+
+            for (index_t pixelId = 0; pixelId < numTotalProperParts_; ++pixelId) {
+                const auto ownerId = parent(pixelId);
+                properPartOwner[(size_t) pixelId] = ownerId;
+                const auto ownerLocalId = localOf(ownerId);
+                if (properHead[(size_t) ownerLocalId] == invalid_index) {
+                    properHead[(size_t) ownerLocalId] = pixelId;
+                } else {
+                    prevProperPart[(size_t) pixelId] = properTail[(size_t) ownerLocalId];
+                    nextProperPart[(size_t) properTail[(size_t) ownerLocalId]] = pixelId;
+                }
+                properTail[(size_t) ownerLocalId] = pixelId;
+                numProperPartsByNode[(size_t) ownerLocalId]++;
+            }
+
+            for (index_t nodeId = numTotalProperParts_; nodeId < n; ++nodeId) {
+                if (nodeId == rootNodeId || !isAlive(nodeId)) {
+                    continue;
+                }
+                linkChildBack(parent(nodeId), nodeId);
+            }
+        }
+
+        /**
+         * @brief Maps a global internal id to a local internal id.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t localOf(index_t nodeId) const {
+            hg_assert(nodeId >= numTotalProperParts_ && nodeId < getGlobalIdSpaceSize(), "Node is not an internal node.");
+            return nodeId - numTotalProperParts_;
+        }
+
+        /**
+         * @brief Maps a local internal id to a global internal id.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t globalOf(index_t localId) const { 
+            return localId + numTotalProperParts_; 
+        }
+
+    public:
+
+        // Iterators/ranges are declared here and implemented after the class body.
+        class ChildrenIterator;             // Iterator over the direct node children of a node.
+        class ChildrenRange;                // Range over the direct node children of a node.
+        class AliveNodeIterator;            // Iterator over alive node global ids.
+        class AliveNodeRange;               // Range over alive node global ids.
+        class PostOrderNodeIterator;   // Iterator over a rooted node subtree in post-order.
+        class PostOrderNodeRange;      // Range over a rooted node subtree in post-order.
+        class PathToRootIterator;           // Iterator over the path from a node to the root.
+        class PathToRootRange;              // Range over the path from a node to the root.
+        class SubtreeNodeIterator;     // Iterator over a rooted node subtree in pre-order.
+        class SubtreeNodeRange;        // Range over a rooted node subtree in pre-order.
+        class DescendantNodeRange;    // Range over node descendants, excluding the node itself.
+        class ProperPartsIterator;          // Iterator over the proper parts directly owned by a node.
+        class ProperPartsRange;             // Range over the proper parts directly owned by a node.
+        class BreadthFirstNodeIterator;// Iterator over a rooted node subtree in breadth-first order.
+        class BreadthFirstNodeRange;   // Range over a rooted node subtree in breadth-first order.
+
+        DynamicComponentTree() = default;
+
+        /**
+         * @brief Constructs a dynamic tree from parent/altitude arrays.
+         * @complexity Time O(N), Space O(N).
+         */
+        template<typename T1, typename T2>
+        DynamicComponentTree(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
+            buildFromParentAltitude(xparent, xaltitude, numProperParts);
+        }
+
+        /**
+         * @brief Builds a max-tree or min-tree from a graph and image.
+         * @complexity Time O(C_component_tree + N), Space O(N).
+         */
+        template<typename graph_t, typename T>
+        DynamicComponentTree(const graph_t &graph, const xt::xexpression<T> &ximage, bool isMaxTree) {
+            auto res =  isMaxTree? component_tree_max_tree(graph, ximage) : component_tree_min_tree(graph, ximage);
+            buildFromParentAltitude(res.tree.parents(), res.altitudes, (index_t) res.tree.num_leaves());
+        }
+
+        /**
+         * @brief Resets this dynamic tree from parent/altitude arrays.
+         * @complexity Time O(N), Space O(N).
+         */
+        template<typename T1, typename T2>
+        void reset(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
+            buildFromParentAltitude(xparent, xaltitude, numProperParts);
+        }
+
+        /**
+         * @brief Returns the number of internal-node slots, alive or free.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumInternalNodeSlots() const { 
+            return numInternalNodeSlots_; 
+        }
+
+        /**
+         * @brief Returns the size of the global id space `[0, L + I)`.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getGlobalIdSpaceSize() const { 
+            return numTotalProperParts_ + numInternalNodeSlots_; 
+        }
+
+        /**
+         * @brief Counts alive leaf nodes in the internal hierarchy.
+         * @complexity Time O(I), Space O(1).
+         */
+        index_t getNumLeafNodes() const {
+            index_t count = 0;
+            for (index_t nodeId = numTotalProperParts_; nodeId < getGlobalIdSpaceSize(); ++nodeId) {
+                if (!isAlive(nodeId)) {
+                    continue;
+                }
+                if (isLeaf(nodeId)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        /**
+         * @brief Returns the total number of proper parts (pixels) in the image domain.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumTotalProperParts() const { 
+            return numTotalProperParts_; 
+        }
+
+        /**
+         * @brief Returns the number of alive internal nodes.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumNodes() const { 
+            return numInternalNodeSlots_ - (index_t) freeNodeSlots.size(); 
+        }
+
+        /**
+         * @brief Tests whether a global id refers to an internal node slot.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool isNode(index_t nodeId) const { 
+            return nodeId >= numTotalProperParts_ && nodeId < getGlobalIdSpaceSize(); 
+        }
+
+        /**
+         * @brief Tests whether a global id refers to a proper part / pixel.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool isProperPart(index_t nodeId) const { 
+            return nodeId >= 0 && nodeId < numTotalProperParts_; 
+        }
+
+        /**
+         * @brief Returns the current root id.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getRoot() const { 
+            return rootNodeId; 
+        }
+
+        /**
+         * @brief Tests whether a node is the current root.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool isRoot(index_t nodeId) const { 
+            return nodeId == rootNodeId; 
+        }
+
+        /**
+         * @brief Returns the number of free internal-node slots currently available for reuse.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumFreeNodeSlots() const { 
+            return (index_t) freeNodeSlots.size(); 
+        }
+
+        /**
+         * @brief Returns the number of direct children of an internal node.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumChildren(index_t nodeId) const { 
+            return numChildrenByNode[(size_t) localOf(nodeId)];
+        }
+
+        /**
+         * @brief Tests whether an internal node has no internal children.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool isLeaf(index_t nodeId) const { 
+            return firstChild[(size_t) localOf(nodeId)] == invalid_index; 
+        }
+
+        /**
+         * @brief Returns the number of direct proper parts currently owned by a given node.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNumProperParts(index_t nodeId) const { 
+            return numProperPartsByNode[(size_t) localOf(nodeId)];
+        }
+
+        /**
+         * @brief Tests whether childId is currently a direct child of parentId.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool hasChild(index_t parentId, index_t childId) const { 
+            return getNodeParent(childId) == parentId;
+        }
+
+        /**
+         * @brief Returns all alive internal nodes.
+         * @complexity Range creation O(1); full iteration O(I).
+         */
+        AliveNodeRange getAliveNodeIds() const { 
+            return AliveNodeRange(this, getNumTotalProperParts(), getGlobalIdSpaceSize()); 
+        }
+
+        /**
+         * @brief Returns direct internal children of a node.
+         * @complexity Range creation O(1); full iteration O(#children).
+         */
+        ChildrenRange getChildren(index_t nodeId) const { 
+            return ChildrenRange(this, firstChild[(size_t) localOf(nodeId)]); 
+        }
+
+        /**
+         * @brief Returns direct proper parts owned by a node.
+         * @complexity Range creation O(1); full iteration O(#proper parts).
+         */
+        ProperPartsRange getProperParts(index_t nodeId) const { 
+            return ProperPartsRange(this, properHead[(size_t) localOf(nodeId)]); 
+        }
+
+        /**
+         * @brief Returns a post-order traversal from the current root.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        PostOrderNodeRange getPostOrderNodes() const { 
+            return PostOrderNodeRange(this, getRoot()); 
+        }
+
+        /**
+         * @brief Returns a post-order traversal rooted at rootNodeId.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        PostOrderNodeRange getPostOrderNodes(index_t rootNodeId) const { 
+            return PostOrderNodeRange(this, rootNodeId); 
+        }
+
+        /**
+         * @brief Returns a breadth-first traversal from the current root.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        BreadthFirstNodeRange getBreadthFirstNodes() const { 
+            return BreadthFirstNodeRange(this, getRoot()); 
+        }
+
+        /**
+         * @brief Returns a breadth-first traversal rooted at rootNodeId.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        BreadthFirstNodeRange getBreadthFirstNodes(index_t rootNodeId) const { 
+            return BreadthFirstNodeRange(this, rootNodeId); 
+        }
+
+        /**
+         * @brief Returns the path from nodeId to the root, both endpoints included.
+         * @complexity Range creation O(1); full iteration O(path length).
+         */
+        PathToRootRange getPathToRootNodes(index_t nodeId) const { 
+            return PathToRootRange(this, nodeId); 
+        }
+
+        /**
+         * @brief Returns the rooted subtree of nodeId in pre-order.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        SubtreeNodeRange getNodeSubtree(index_t nodeId) const { 
+            return SubtreeNodeRange(this, nodeId); 
+        }
+
+        /**
+         * @brief Returns descendants of nodeId in pre-order, excluding nodeId.
+         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         */
+        DescendantNodeRange getDescendants(index_t nodeId) const { 
+            return DescendantNodeRange(this, nodeId); 
+        }
+
+        /**
+         * @brief Returns the parent of an internal node.
+         * @warning nodeId must be an internal node.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNodeParent(index_t nodeId) const {
+            return nodeParent[(size_t) localOf(nodeId)];
+        }
+
+        /**
+         * @brief Returns the altitude of an internal node.
+         * @warning nodeId must be an internal node.
+         * @complexity Time O(1), Space O(1).
+         */
+        altitude_t getNodeAltitude(index_t nodeId) const {
+            return nodeAltitude[(size_t) localOf(nodeId)];
+        }
+
+        /**
+         * @brief Returns the current owner / smallest component of a proper part.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getSmallestComponent(index_t pixelId) const {
+            if (pixelId >= 0 && pixelId < this->getNumTotalProperParts()) {
+                return properPartOwner[(size_t) pixelId];
+            }
+            return invalid_index;
+        }
+
+        /**
+         * @brief Tests whether an internal node slot is alive.
+         * @complexity Time O(1), Space O(1).
+         */
+        bool isAlive(index_t nodeId) const {
+            if (!isNode(nodeId)) {
+                return false;
+            }
+            return getNodeParent(nodeId) != invalid_index;
+        }
+
+        /**
+         * @brief Moves one direct proper part from sourceNodeId to targetNodeId.
+         * @complexity Time O(1), Space O(1).
+         */
+        void moveProperPart(index_t targetNodeId, index_t sourceNodeId, index_t pixelId) {
+            const auto targetLocalId = localOf(targetNodeId);
+            const auto sourceLocalId = localOf(sourceNodeId);
+            const auto prevPixel = prevProperPart[(size_t) pixelId];
+            const auto nextPixel = nextProperPart[(size_t) pixelId];
+
+            if (prevPixel == invalid_index) {
+                properHead[(size_t) sourceLocalId] = nextPixel;
+            } else {
+                nextProperPart[(size_t) prevPixel] = nextPixel;
+            }
+
+            if (nextPixel == invalid_index) {
+                properTail[(size_t) sourceLocalId] = prevPixel;
+            } else {
+                prevProperPart[(size_t) nextPixel] = prevPixel;
+            }
+
+            numProperPartsByNode[(size_t) sourceLocalId]--;
+
+            prevProperPart[(size_t) pixelId] = properTail[(size_t) targetLocalId];
+            nextProperPart[(size_t) pixelId] = invalid_index;
+
+            if (numProperPartsByNode[(size_t) targetLocalId] == 0) {
+                properHead[(size_t) targetLocalId] = pixelId;
+                properTail[(size_t) targetLocalId] = pixelId;
+                numProperPartsByNode[(size_t) targetLocalId] = 1;
+            } else {
+                nextProperPart[(size_t) properTail[(size_t) targetLocalId]] = pixelId;
+                properTail[(size_t) targetLocalId] = pixelId;
+                numProperPartsByNode[(size_t) targetLocalId] += 1;
+            }
+            properPartOwner[(size_t) pixelId] = targetNodeId;
+            properPartVersion++;
+        }
+
+        /**
+         * @brief Moves all direct proper parts of nodeB to nodeA.
+         * @complexity Time O(k), Space O(1), where k is the number of moved proper parts.
+         */
+        void moveProperParts(index_t nodeA, index_t nodeB) {
+            const auto localA = localOf(nodeA);
+            const auto localB = localOf(nodeB);
+            auto movedHead = properHead[(size_t) localB];
+            if (movedHead == invalid_index) {
+                return;
+            }
+
+            for (auto pixelId = movedHead; pixelId != invalid_index; pixelId = nextProperPart[(size_t) pixelId]) {
+                properPartOwner[(size_t) pixelId] = nodeA;
+            }
+
+            if (numProperPartsByNode[(size_t) localA] == 0) {
+                properHead[(size_t) localA] = movedHead;
+                properTail[(size_t) localA] = properTail[(size_t) localB];
+                numProperPartsByNode[(size_t) localA] = numProperPartsByNode[(size_t) localB];
+            } else {
+                prevProperPart[(size_t) movedHead] = properTail[(size_t) localA];
+                nextProperPart[(size_t) properTail[(size_t) localA]] = movedHead;
+                properTail[(size_t) localA] = properTail[(size_t) localB];
+                numProperPartsByNode[(size_t) localA] += numProperPartsByNode[(size_t) localB];
+            }
+
+            properHead[(size_t) localB] = invalid_index;
+            properTail[(size_t) localB] = invalid_index;
+            numProperPartsByNode[(size_t) localB] = 0;
+            properPartVersion++;
+        }
+
+        /**
+         * @brief Sets nodeId as the tree root.
+         * @warning If nodeId is attached, it is detached first.
+         * @complexity Time O(1), Space O(1).
+         */
+        void setRoot(index_t nodeId) {
+            const auto oldRoot = getRoot();
+            const auto oldParentId = getNodeParent(nodeId);
+            if (oldParentId != invalid_index && oldParentId != nodeId) {
+                unlinkChild(nodeId);
+            }
+            if (oldRoot != invalid_index && oldRoot != nodeId && isNode(oldRoot) && isAlive(oldRoot)) {
+                const auto oldRootLocalId = localOf(oldRoot);
+                nodeParent[(size_t) oldRootLocalId] = getNodeParent(oldRoot);
+                nodeAltitude[(size_t) oldRootLocalId] = getNodeAltitude(oldRoot);
+            }
+            rootNodeId = nodeId;
+            const auto localId = localOf(nodeId);
+            nodeParent[(size_t) localId] = nodeId;
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Allocates a released internal-node slot (LIFO free list).
+         * @return Global internal id, or invalid_index if there is no free slot.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t allocateNode(altitude_t altitudeValue) {
+            if (freeNodeSlots.empty()) {
+                return invalid_index;
+            }
+            const auto localId = freeNodeSlots.back();
+            freeNodeSlots.pop_back();
+            const auto nodeId = globalOf(localId);
+            if (nodeId != invalid_index) {
+                nodeParent[(size_t) localId] = nodeId;
+                nodeAltitude[(size_t) localId] = altitudeValue;
+                firstChild[(size_t) localId] = invalid_index;
+                lastChild[(size_t) localId] = invalid_index;
+                nextSibling[(size_t) localId] = invalid_index;
+                prevSibling[(size_t) localId] = invalid_index;
+                numChildrenByNode[(size_t) localId] = 0;
+                properHead[(size_t) localId] = invalid_index;
+                properTail[(size_t) localId] = invalid_index;
+                numProperPartsByNode[(size_t) localId] = 0;
+            }
+            nodeStructureVersion++;
+            return nodeId;
+        }
+
+        /**
+         * @brief Releases an internal-node slot back to the free list.
+         * @warning Node must be detached and empty.
+         * @complexity Time O(1), Space O(1).
+         */
+        void releaseNode(index_t nodeId) {
+            hg_assert(isAlive(nodeId), "releaseNode expects an alive internal node.");
+            hg_assert(getNodeParent(nodeId) == nodeId, "releaseNode expects a detached node.");
+            hg_assert(firstChild[(size_t) localOf(nodeId)] == invalid_index, "releaseNode expects node with no children.");
+            hg_assert(numProperPartsByNode[(size_t) localOf(nodeId)] == 0, "releaseNode expects node with no proper parts.");
+            const auto localId = localOf(nodeId);
+            firstChild[(size_t) localId] = invalid_index;
+            lastChild[(size_t) localId] = invalid_index;
+            nextSibling[(size_t) localId] = invalid_index;
+            prevSibling[(size_t) localId] = invalid_index;
+            numChildrenByNode[(size_t) localId] = 0;
+            properHead[(size_t) localId] = invalid_index;
+            properTail[(size_t) localId] = invalid_index;
+            numProperPartsByNode[(size_t) localId] = 0;
+            nodeParent[(size_t) localId] = invalid_index;
+            nodeAltitude[(size_t) localId] = altitude_t{};
+            freeNodeSlots.push_back(localId);
+            nodeStructureVersion++;
+        }
+
+        /**
+         * @brief Removes a direct child from a parent, optionally releasing the child slot.
+         * @complexity Time O(1), Space O(1).
+         */
+        void removeChild(index_t parentId, index_t childId, bool releaseNodeFlag) {
+            const auto childWasAlive = isNode(childId) && isAlive(childId);
+            const auto wasDirectChild = childWasAlive && getNodeParent(childId) == parentId;
+            if (!wasDirectChild) {
+                return;
+            }
+            unlinkChild(childId);
+            const auto childLocalId = localOf(childId);
+            if (releaseNodeFlag) {
+                nodeParent[(size_t) childLocalId] = invalid_index;
+                nodeAltitude[(size_t) childLocalId] = altitude_t{};
+                freeNodeSlots.push_back(childLocalId);
+                nodeStructureVersion++;
+            } else {
+                nodeParent[(size_t) childLocalId] = childId;
+            }
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Attaches a detached node as the last child of parentId.
+         * @complexity Time O(1), Space O(1).
+         */
+        void attachNode(index_t parentId, index_t nodeId) {
+            linkChildBack(parentId, nodeId);
+            const auto localId = localOf(nodeId);
+            nodeParent[(size_t) localId] = parentId;
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Detaches an attached node from its parent.
+         * @complexity Time O(1), Space O(1).
+         */
+        void detachNode(index_t nodeId) {
+            unlinkChild(nodeId);
+            const auto localId = localOf(nodeId);
+            nodeParent[(size_t) localId] = nodeId;
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Moves an attached node under a new parent.
+         * @complexity Time O(1), Space O(1).
+         */
+        void moveNode(index_t nodeId, index_t newParentId) {
+            const auto oldParentId = getNodeParent(nodeId);
+            if (oldParentId != newParentId) {
+                unlinkChild(nodeId);
+                linkChildBack(newParentId, nodeId);
+            }
+            const auto localId = localOf(nodeId);
+            nodeParent[(size_t) localId] = newParentId;
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Moves all direct children of sourceId under parentId.
+         * @complexity Time O(k), Space O(1), where k is the number of moved children.
+         */
+        void moveChildren(index_t parentId, index_t sourceId) {
+            const auto parentLocalId = localOf(parentId);
+            const auto sourceLocalId = localOf(sourceId);
+            auto firstLocalId = firstChild[(size_t) sourceLocalId];
+            if (firstLocalId == invalid_index) {
+                return;
+            }
+            auto lastLocalId = lastChild[(size_t) sourceLocalId];
+            auto movedCount = numChildrenByNode[(size_t) sourceLocalId];
+            auto tail = lastChild[(size_t) parentLocalId];
+
+            firstChild[(size_t) sourceLocalId] = invalid_index;
+            lastChild[(size_t) sourceLocalId] = invalid_index;
+            numChildrenByNode[(size_t) sourceLocalId] = 0;
+            prevSibling[(size_t) firstLocalId] = invalid_index;
+            nextSibling[(size_t) lastLocalId] = invalid_index;
+
+            if (tail == invalid_index) {
+                firstChild[(size_t) parentLocalId] = firstLocalId;
+                lastChild[(size_t) parentLocalId] = lastLocalId;
+            } else {
+                nextSibling[(size_t) tail] = firstLocalId;
+                prevSibling[(size_t) firstLocalId] = tail;
+                lastChild[(size_t) parentLocalId] = lastLocalId;
+            }
+            numChildrenByNode[(size_t) parentLocalId] += movedCount;
+
+            for (auto childLocalId = firstLocalId; childLocalId != invalid_index; childLocalId = nextSibling[(size_t) childLocalId]) {
+                nodeParent[(size_t) childLocalId] = parentId;
+            }
+            topologyVersion++;
+        }
+
+        /**
+         * @brief Removes a subtree and absorbs its direct proper parts into the parent.
+         * @warning nodeId must be a non-root alive internal node.
+         * @complexity Time O(s + p), Space O(1), where s is the number of nodes in the
+         *             subtree and p the number of proper parts owned by those nodes.
+         */
+        void pruneNode(index_t nodeId) {
+            const auto parentId = this->getNodeParent(nodeId);
+            auto descendToDeepestLastChild = [this](index_t startId) {
+                auto currentId = startId;
+                while (!isLeaf(currentId)) {
+                    currentId = globalOf(lastChild[(size_t) localOf(currentId)]);
+                }
+                return currentId;
+            };
+            auto currentId = descendToDeepestLastChild(nodeId);
+
+            while (true) {
+                if (currentId == nodeId) {
+                    detachNodeInBackend(nodeId);
+                    moveProperPartsInBackend(parentId, nodeId);
+                    releaseNodeSlot(nodeId);
+                    topologyVersion++;
+                    nodeStructureVersion++;
+                    properPartVersion++;
+                    break;
+                }
+
+                const auto currentParentId = getNodeParent(currentId);
+                detachNodeInBackend(currentId);
+                moveProperPartsInBackend(parentId, currentId);
+                releaseNodeSlot(currentId);
+                topologyVersion++;
+                nodeStructureVersion++;
+                properPartVersion++;
+
+                if (isLeaf(currentParentId)) {
+                    currentId = currentParentId;
+                } else {
+                    currentId = descendToDeepestLastChild(currentParentId);
+                }
+            }
+        }
+
+        /**
+         * @brief Merges a node into its parent, reattaching direct children and proper parts.
+         * @warning nodeId must be a non-root alive internal node.
+         * @complexity Time O(c + p), Space O(1), where c is the number of direct children and
+         *             p the number of direct proper parts of nodeId.
+         */
+        void mergeNodeIntoParent(index_t nodeId) {
+            const auto parentId = getNodeParent(nodeId);
+            detachNodeInBackend(nodeId);
+            moveChildren(parentId, nodeId);
+            moveProperPartsInBackend(parentId, nodeId);
+            releaseNodeSlot(nodeId);
+            topologyVersion++;
+            nodeStructureVersion++;
+            properPartVersion++;
+        }
+
+    };
+
+
+
+
+
+    // -------------------------------------------------------------------------
+    // Iterators and ranges implementation
+    // -------------------------------------------------------------------------
+
+
+    /**
+     * @brief Iterator over the direct internal children of a node.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::ChildrenIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t currentLocal_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::forward_iterator_tag;
+
+        ChildrenIterator() = default;
+        ChildrenIterator(const DynamicComponentTree *tree, index_t currentLocal, std::size_t expectedVersion)
+                : tree_(tree), currentLocal_(currentLocal), expectedVersion_(expectedVersion) {
+        }
+
+        index_t operator*() const {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            return tree_->globalOf(currentLocal_);
+        }
+
+        ChildrenIterator &operator++() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            if (currentLocal_ != invalid_index) {
+                currentLocal_ = tree_->nextSibling[(size_t) currentLocal_];
+            }
+            return *this;
+        }
+
+        bool operator==(const ChildrenIterator &other) const {
+            return tree_ == other.tree_ && currentLocal_ == other.currentLocal_;
+        }
+
+        bool operator!=(const ChildrenIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over the direct internal children of a node.
+     * @usage `for (auto n : tree.getChildren(nodeId)) { ... }`
+     * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of children.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::ChildrenRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t firstLocal_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        ChildrenRange() = default;
+        ChildrenRange(const DynamicComponentTree *tree, index_t firstLocal)
+                : tree_(tree), firstLocal_(firstLocal), expectedVersion_(tree ? tree->topologyVersion : 0) {
+        }
+
+        ChildrenIterator begin() const { return ChildrenIterator(tree_, firstLocal_, expectedVersion_); }
+        ChildrenIterator end() const { return ChildrenIterator(tree_, invalid_index, expectedVersion_); }
+    };
+
+    /**
+     * @brief Iterator over alive internal-node global ids.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::AliveNodeIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t current_ = invalid_index;
+        index_t end_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+        void settle() {
+            while (tree_ && current_ < end_) {
+                tree_->checkNodeIteratorVersion(expectedVersion_);
+                if (tree_->getNodeParent(current_) != invalid_index) {
+                    return;
+                }
+                current_++;
+            }
+            current_ = end_;
+        }
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::forward_iterator_tag;
+
+        AliveNodeIterator() = default;
+        AliveNodeIterator(const DynamicComponentTree *tree, index_t current, index_t end, std::size_t expectedVersion)
+                : tree_(tree), current_(current), end_(end), expectedVersion_(expectedVersion) {
+            settle();
+        }
+
+        index_t operator*() const {
+            tree_->checkNodeIteratorVersion(expectedVersion_);
+            return current_;
+        }
+
+        AliveNodeIterator &operator++() {
+            tree_->checkNodeIteratorVersion(expectedVersion_);
+            current_++;
+            settle();
+            return *this;
+        }
+
+        bool operator==(const AliveNodeIterator &other) const {
+            return tree_ == other.tree_ && current_ == other.current_ && end_ == other.end_;
+        }
+
+        bool operator!=(const AliveNodeIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over alive internal-node global ids.
+     * @usage `for (auto n : tree.getAliveNodeIds()) { ... }`
+     * @complexity Time O(1) to create, O(I) to iterate, Space O(1), where I is the number of node slots.
+     * @warning Lazy range. Invalidated if the node set changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::AliveNodeRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t begin_ = 0;
+        index_t end_ = 0;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        AliveNodeRange() = default;
+        AliveNodeRange(const DynamicComponentTree *tree, index_t begin, index_t end)
+                : tree_(tree), begin_(begin), end_(end), expectedVersion_(tree ? tree->nodeStructureVersion : 0) {
+        }
+
+        AliveNodeIterator begin() const { return AliveNodeIterator(tree_, begin_, end_, expectedVersion_); }
+        AliveNodeIterator end() const { return AliveNodeIterator(tree_, end_, end_, expectedVersion_); }
+    };
+
+    /**
+     * @brief Iterator over an internal rooted subtree in post-order.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::PostOrderNodeIterator {
+    private:
+        struct Item {
+            index_t nodeId = invalid_index;
+            bool expanded = false;
+        };
+
+        const DynamicComponentTree *tree_ = nullptr;
+        std::vector<Item> stack_;
+        index_t current_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+        void settle() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            current_ = invalid_index;
+            while (!stack_.empty()) {
+                auto &top = stack_.back();
+                if (!top.expanded) {
+                    top.expanded = true;
+                    auto nodeLocal = tree_->localOf(top.nodeId);
+                    auto childLocal = tree_->lastChild[(size_t) nodeLocal];
+                    while (childLocal != invalid_index) {
+                        stack_.push_back(Item{tree_->globalOf(childLocal), false});
+                        childLocal = tree_->prevSibling[(size_t) childLocal];
+                    }
+                } else {
+                    current_ = top.nodeId;
+                    return;
+                }
+            }
+        }
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::input_iterator_tag;
+
+        PostOrderNodeIterator() = default;
+        PostOrderNodeIterator(const DynamicComponentTree *tree, index_t rootNodeId, std::size_t expectedVersion)
+                : tree_(tree), expectedVersion_(expectedVersion) {
+            if (!tree_ || rootNodeId < tree_->getNumTotalProperParts() || rootNodeId >= tree_->getGlobalIdSpaceSize()) {
+                current_ = invalid_index;
+                return;
+            }
+            stack_.push_back(Item{rootNodeId, false});
+            settle();
+        }
+
+        index_t operator*() const {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            return current_;
+        }
+
+        PostOrderNodeIterator &operator++() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            if (!stack_.empty()) {
+                stack_.pop_back();
+            }
+            settle();
+            return *this;
+        }
+
+        bool operator==(const PostOrderNodeIterator &other) const { return current_ == other.current_; }
+        bool operator!=(const PostOrderNodeIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over an internal rooted subtree in post-order.
+     * @usage `for (auto n : tree.getPostOrderNodes()) { ... }`
+     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::PostOrderNodeRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t rootNodeId_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        PostOrderNodeRange() = default;
+        PostOrderNodeRange(const DynamicComponentTree *tree, index_t rootNodeId)
+                : tree_(tree), rootNodeId_(rootNodeId), expectedVersion_(tree ? tree->topologyVersion : 0) {
+        }
+
+        PostOrderNodeIterator begin() const { return PostOrderNodeIterator(tree_, rootNodeId_, expectedVersion_); }
+        PostOrderNodeIterator end() const { return PostOrderNodeIterator(); }
+    };
+
+    /**
+     * @brief Iterator over the path from a node to the root.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::PathToRootIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t currentId_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::input_iterator_tag;
+
+        PathToRootIterator() = default;
+        PathToRootIterator(const DynamicComponentTree *tree, index_t startId, std::size_t expectedVersion)
+                : tree_(tree), currentId_(startId), expectedVersion_(expectedVersion) {
+        }
+
+        index_t operator*() const {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            return currentId_;
+        }
+
+        PathToRootIterator &operator++() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            if (!tree_ || currentId_ == invalid_index) {
+                currentId_ = invalid_index;
+                return *this;
+            }
+            auto parentId = tree_->getNodeParent(currentId_);
+            currentId_ = (parentId == currentId_) ? invalid_index : parentId;
+            return *this;
+        }
+
+        bool operator==(const PathToRootIterator &other) const { return currentId_ == other.currentId_; }
+        bool operator!=(const PathToRootIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over the path from a node to the root.
+     * @usage `for (auto n : tree.getPathToRootNodes(nodeId)) { ... }`
+     * @complexity Time O(1) to create, O(h) to iterate, Space O(1), where h is path length.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::PathToRootRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t startId_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        PathToRootRange() = default;
+        PathToRootRange(const DynamicComponentTree *tree, index_t nodeId)
+                : tree_(tree), startId_(nodeId), expectedVersion_(tree ? tree->topologyVersion : 0) {
+        }
+
+        PathToRootIterator begin() const {
+            if (!tree_ || startId_ < 0 || startId_ >= tree_->getGlobalIdSpaceSize()) {
+                return PathToRootIterator();
+            }
+            return PathToRootIterator(tree_, startId_, expectedVersion_);
+        }
+
+        PathToRootIterator end() const { return PathToRootIterator(); }
+    };
+
+    /**
+     * @brief Iterator over an internal rooted subtree in pre-order.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::SubtreeNodeIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        std::vector<index_t> stack_;
+        index_t current_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+        void settle() { current_ = stack_.empty() ? invalid_index : stack_.back(); }
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::input_iterator_tag;
+
+        SubtreeNodeIterator() = default;
+        SubtreeNodeIterator(const DynamicComponentTree *tree, index_t rootNodeId, std::size_t expectedVersion)
+                : tree_(tree), expectedVersion_(expectedVersion) {
+            if (!tree_ || rootNodeId < tree_->getNumTotalProperParts() || rootNodeId >= tree_->getGlobalIdSpaceSize()) {
+                current_ = invalid_index;
+                return;
+            }
+            stack_.push_back(rootNodeId);
+            settle();
+        }
+
+        index_t operator*() const {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            return current_;
+        }
+
+        SubtreeNodeIterator &operator++() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            if (stack_.empty()) {
+                current_ = invalid_index;
+                return *this;
+            }
+            auto nodeId = stack_.back();
+            stack_.pop_back();
+            auto nodeLocal = tree_->localOf(nodeId);
+            auto childLocal = tree_->lastChild[(size_t) nodeLocal];
+            while (childLocal != invalid_index) {
+                stack_.push_back(tree_->globalOf(childLocal));
+                childLocal = tree_->prevSibling[(size_t) childLocal];
+            }
+            settle();
+            return *this;
+        }
+
+        bool operator==(const SubtreeNodeIterator &other) const { return current_ == other.current_; }
+        bool operator!=(const SubtreeNodeIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over an internal rooted subtree in pre-order.
+     * @usage `for (auto n : tree.getNodeSubtree(nodeId)) { ... }`
+     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::SubtreeNodeRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t rootNodeId_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        SubtreeNodeRange() = default;
+        SubtreeNodeRange(const DynamicComponentTree *tree, index_t rootNodeId)
+                : tree_(tree), rootNodeId_(rootNodeId), expectedVersion_(tree ? tree->topologyVersion : 0) {
+        }
+
+        SubtreeNodeIterator begin() const { return SubtreeNodeIterator(tree_, rootNodeId_, expectedVersion_); }
+        SubtreeNodeIterator end() const { return SubtreeNodeIterator(); }
+    };
+
+    /**
+     * @brief Range over the descendants of a node, excluding the node itself.
+     * @usage `for (auto n : tree.getDescendants(nodeId)) { ... }`
+     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::DescendantNodeRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t rootNodeId_ = invalid_index;
+
+    public:
+        DescendantNodeRange() = default;
+        DescendantNodeRange(const DynamicComponentTree *tree, index_t rootNodeId)
+                : tree_(tree), rootNodeId_(rootNodeId) {
+        }
+
+        SubtreeNodeIterator begin() const {
+            auto it = SubtreeNodeIterator(tree_, rootNodeId_, tree_ ? tree_->topologyVersion : 0);
+            if (it != SubtreeNodeIterator()) {
+                ++it;
+            }
+            return it;
+        }
+
+        SubtreeNodeIterator end() const { return SubtreeNodeIterator(); }
+    };
+
+    /**
+     * @brief Iterator over the proper parts directly owned by a node.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::ProperPartsIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t current_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::forward_iterator_tag;
+
+        ProperPartsIterator() = default;
+        ProperPartsIterator(const DynamicComponentTree *tree, index_t current, std::size_t expectedVersion)
+                : tree_(tree), current_(current), expectedVersion_(expectedVersion) {
+        }
+
+        index_t operator*() const {
+            tree_->checkProperPartIteratorVersion(expectedVersion_);
+            return current_;
+        }
+
+        ProperPartsIterator &operator++() {
+            tree_->checkProperPartIteratorVersion(expectedVersion_);
+            if (current_ != invalid_index) {
+                current_ = tree_->nextProperPart[(size_t) current_];
+            }
+            return *this;
+        }
+
+        bool operator==(const ProperPartsIterator &other) const {
+            return tree_ == other.tree_ && current_ == other.current_;
+        }
+
+        bool operator!=(const ProperPartsIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over the proper parts directly owned by a node.
+     * @usage `for (auto p : tree.getProperParts(nodeId)) { ... }`
+     * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of proper parts.
+     * @warning Lazy range. Invalidated if proper-part ownership changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::ProperPartsRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t first_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        ProperPartsRange() = default;
+        ProperPartsRange(const DynamicComponentTree *tree, index_t first)
+                : tree_(tree), first_(first), expectedVersion_(tree ? tree->properPartVersion : 0) {
+        }
+
+        ProperPartsIterator begin() const { return ProperPartsIterator(tree_, first_, expectedVersion_); }
+        ProperPartsIterator end() const { return ProperPartsIterator(tree_, invalid_index, expectedVersion_); }
+    };
+
+    /**
+     * @brief Iterator over an internal rooted subtree in breadth-first order.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::BreadthFirstNodeIterator {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        std::vector<index_t> queue_;
+        size_t head_ = 0;
+        std::size_t expectedVersion_ = 0;
+
+        bool empty() const { return head_ >= queue_.size(); }
+
+    public:
+        using value_type = index_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const index_t *;
+        using reference = const index_t &;
+        using iterator_category = std::input_iterator_tag;
+
+        BreadthFirstNodeIterator() = default;
+        BreadthFirstNodeIterator(const DynamicComponentTree *tree, index_t rootNodeId, std::size_t expectedVersion)
+                : tree_(tree), expectedVersion_(expectedVersion) {
+            if (!tree_ || rootNodeId < tree_->getNumTotalProperParts() || rootNodeId >= tree_->getGlobalIdSpaceSize()) {
+                head_ = 0;
+                return;
+            }
+            queue_.push_back(rootNodeId);
+        }
+
+        index_t operator*() const {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            return queue_[head_];
+        }
+
+        BreadthFirstNodeIterator &operator++() {
+            tree_->checkTopologyIteratorVersion(expectedVersion_);
+            if (empty()) {
+                return *this;
+            }
+            const auto nodeId = queue_[head_++];
+            auto nodeLocal = tree_->localOf(nodeId);
+            auto childLocal = tree_->firstChild[(size_t) nodeLocal];
+            while (childLocal != invalid_index) {
+                queue_.push_back(tree_->globalOf(childLocal));
+                childLocal = tree_->nextSibling[(size_t) childLocal];
+            }
+            return *this;
+        }
+
+        bool operator==(const BreadthFirstNodeIterator &other) const { return empty() == other.empty(); }
+        bool operator!=(const BreadthFirstNodeIterator &other) const { return !(*this == other); }
+    };
+
+    /**
+     * @brief Range over an internal rooted subtree in breadth-first order.
+     * @usage `for (auto n : tree.getBreadthFirstNodes()) { ... }`
+     * @complexity Time O(1) to create, O(S) to iterate, Space O(w), where S is subtree size and w the frontier width.
+     * @warning Lazy range. Invalidated if the tree topology changes during iteration.
+     */
+    template<typename altitude_t>
+    class DynamicComponentTree<altitude_t>::BreadthFirstNodeRange {
+    private:
+        const DynamicComponentTree *tree_ = nullptr;
+        index_t rootNodeId_ = invalid_index;
+        std::size_t expectedVersion_ = 0;
+
+    public:
+        BreadthFirstNodeRange() = default;
+        BreadthFirstNodeRange(const DynamicComponentTree *tree, index_t rootNodeId)
+                : tree_(tree), rootNodeId_(rootNodeId), expectedVersion_(tree ? tree->topologyVersion : 0) {
+        }
+
+        BreadthFirstNodeIterator begin() const { return BreadthFirstNodeIterator(tree_, rootNodeId_, expectedVersion_); }
+        BreadthFirstNodeIterator end() const { return BreadthFirstNodeIterator(); }
+    };
+
+} // namespace hg

--- a/include/higra/detail/hierarchy/dynamic_component_tree.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree.hpp
@@ -508,6 +508,26 @@ namespace hg::detail::hierarchy {
         }
 
         /**
+         * @brief Returns the first direct child of an internal node.
+         * @return Global child id, or `invalid_index` when `nodeId` has no child.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getFirstChild(index_t nodeId) const {
+            const auto childLocalId = firstChild[(size_t) localOf(nodeId)];
+            return childLocalId == invalid_index ? invalid_index : globalOf(childLocalId);
+        }
+
+        /**
+         * @brief Returns the next sibling of an internal node.
+         * @return Global sibling id, or `invalid_index` when `nodeId` is the last sibling.
+         * @complexity Time O(1), Space O(1).
+         */
+        index_t getNextSibling(index_t nodeId) const {
+            const auto siblingLocalId = nextSibling[(size_t) localOf(nodeId)];
+            return siblingLocalId == invalid_index ? invalid_index : globalOf(siblingLocalId);
+        }
+
+        /**
          * @brief Tests whether an internal node has no internal children.
          * @complexity Time O(1), Space O(1).
          */

--- a/include/higra/detail/hierarchy/dynamic_component_tree.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree.hpp
@@ -14,11 +14,11 @@
 #include <iterator>
 #include <vector>
 
-#include "higra/hierarchy/component_tree.hpp"
 #include "higra/structure/array.hpp"
+#include "higra/structure/tree_graph.hpp"
 #include "higra/utils.hpp"
 
-namespace hg {
+namespace hg::detail::hierarchy {
 
     /**
      * @brief Dynamic representation of a component tree with separated internal-node and proper-part storage.
@@ -47,7 +47,7 @@ namespace hg {
      *
      * Local-slot policy:
      *  - mutable internal hierarchy arrays (`firstChild`, `lastChild`, `nextSibling`,
-     *    `prevSibling`, `numChildrenByNode`, `nodeParent`, `nodeAltitude`) are indexed by
+     *    `prevSibling`, `numChildrenByNode`, `nodeParent`) are indexed by
      *    and store local node-slot ids when applicable;
      *  - proper-part ownership arrays are indexed by global proper-part ids `[0, L)`;
      *  - public APIs still expose global ids to stay consistent with Higra conventions.
@@ -66,10 +66,7 @@ namespace hg {
      *
      * Traversal ranges are lazy: creation is O(1); full iteration cost is linear in the
      * number of returned elements.
-     *
-     * @tparam altitude_t Scalar altitude type.
      */
-    template<typename altitude_t>
     class DynamicComponentTree {
     private:
         // ---------------------------------------------------------------------
@@ -87,7 +84,6 @@ namespace hg {
         // Internal-node arrays, indexed by local node-slot id [0, I).
         // Values are global internal ids [L, N) or invalid_index when appropriate.
         std::vector<index_t> nodeParent;
-        std::vector<altitude_t> nodeAltitude;
 
         // Proper-part ownership, indexed by proper-part global id [0, L).
         // Values are global internal ids [L, N).
@@ -225,7 +221,6 @@ namespace hg {
             properTail[(size_t) localId] = invalid_index;
             numProperPartsByNode[(size_t) localId] = 0;
             nodeParent[(size_t) localId] = invalid_index;
-            nodeAltitude[(size_t) localId] = altitude_t{};
             freeNodeSlots.push_back(localId);
         }
 
@@ -266,7 +261,6 @@ namespace hg {
 
             freeNodeSlots.clear();
             nodeParent.resize((size_t) numInternalNodeSlots_);
-            nodeAltitude.resize((size_t) numInternalNodeSlots_);
             properPartOwner.resize((size_t) numTotalProperParts_);
 
             properHead.assign((size_t) numInternalNodeSlots_, invalid_index);
@@ -285,21 +279,17 @@ namespace hg {
         }
 
         /**
-         * @brief Builds the dynamic tree from Higra parent/altitude arrays.
+         * @brief Builds the dynamic tree from Higra parent arrays.
          * @complexity Time O(N), Space O(N).
          */
-        template<typename T1, typename T2>
-        void buildFromParentAltitude(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
+        template<typename T1>
+        void buildFromParent(const xt::xexpression<T1> &xparent, index_t numProperParts) {
             auto &sourceParent = xparent.derived_cast();
-            auto &sourceAltitude = xaltitude.derived_cast();
 
             hg_assert_1d_array(sourceParent);
-            hg_assert_1d_array(sourceAltitude);
             hg_assert_integral_value_type(sourceParent);
-            hg_assert_same_shape(sourceParent, sourceAltitude);
 
             const auto parent = xt::cast<index_t>(sourceParent);
-            const auto altitude = xt::cast<altitude_t>(sourceAltitude);
             const index_t n = (index_t) parent.size();
 
             hg_assert(n > 0, "DynamicComponentTree cannot be empty.");
@@ -311,7 +301,6 @@ namespace hg {
             for (index_t nodeId = numTotalProperParts_; nodeId < n; ++nodeId) {
                 const auto localId = localOf(nodeId);
                 nodeParent[(size_t) localId] = parent(nodeId);
-                nodeAltitude[(size_t) localId] = altitude(nodeId);
                 if (parent(nodeId) == invalid_index) {
                     freeNodeSlots.push_back(localId);
                 }
@@ -337,6 +326,12 @@ namespace hg {
                 }
                 linkChildBack(parent(nodeId), nodeId);
             }
+        }
+
+        template<typename T>
+        index_t inferNumProperParts(const xt::xexpression<T> &xparent) const {
+            const tree inferredTree(xparent);
+            return (index_t) inferredTree.num_leaves();
         }
 
         /**
@@ -378,31 +373,41 @@ namespace hg {
         DynamicComponentTree() = default;
 
         /**
-         * @brief Constructs a dynamic tree from parent/altitude arrays.
+         * @brief Constructs a dynamic tree from parent arrays using Higra tree conventions.
+         * @warning The parent array is expected to follow the Higra tree convention, with proper parts
+         *          occupying the prefix `[0, L)`.
          * @complexity Time O(N), Space O(N).
          */
-        template<typename T1, typename T2>
-        DynamicComponentTree(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
-            buildFromParentAltitude(xparent, xaltitude, numProperParts);
+        template<typename T1>
+        explicit DynamicComponentTree(const xt::xexpression<T1> &xparent) {
+            buildFromParent(xparent, inferNumProperParts(xparent));
         }
 
         /**
-         * @brief Builds a max-tree or min-tree from a graph and image.
-         * @complexity Time O(C_component_tree + N), Space O(N).
+         * @brief Constructs a dynamic tree from a Higra tree.
+         * @complexity Time O(N), Space O(N).
          */
-        template<typename graph_t, typename T>
-        DynamicComponentTree(const graph_t &graph, const xt::xexpression<T> &ximage, bool isMaxTree) {
-            auto res =  isMaxTree? component_tree_max_tree(graph, ximage) : component_tree_min_tree(graph, ximage);
-            buildFromParentAltitude(res.tree.parents(), res.altitudes, (index_t) res.tree.num_leaves());
+        explicit DynamicComponentTree(const tree &inputTree) {
+            buildFromParent(inputTree.parents(), (index_t) inputTree.num_leaves());
         }
 
         /**
-         * @brief Resets this dynamic tree from parent/altitude arrays.
+         * @brief Resets this dynamic tree from parent arrays using Higra tree conventions.
+         * @warning The parent array is expected to follow the Higra tree convention, with proper parts
+         *          occupying the prefix `[0, L)`.
          * @complexity Time O(N), Space O(N).
          */
-        template<typename T1, typename T2>
-        void reset(const xt::xexpression<T1> &xparent, const xt::xexpression<T2> &xaltitude, index_t numProperParts) {
-            buildFromParentAltitude(xparent, xaltitude, numProperParts);
+        template<typename T1>
+        void reset(const xt::xexpression<T1> &xparent) {
+            buildFromParent(xparent, inferNumProperParts(xparent));
+        }
+
+        /**
+         * @brief Resets this dynamic tree from a Higra tree.
+         * @complexity Time O(N), Space O(N).
+         */
+        void reset(const tree &inputTree) {
+            buildFromParent(inputTree.parents(), (index_t) inputTree.num_leaves());
         }
 
         /**
@@ -530,81 +535,61 @@ namespace hg {
          * @brief Returns all alive internal nodes.
          * @complexity Range creation O(1); full iteration O(I).
          */
-        AliveNodeRange getAliveNodeIds() const { 
-            return AliveNodeRange(this, getNumTotalProperParts(), getGlobalIdSpaceSize()); 
-        }
+        AliveNodeRange getAliveNodeIds() const;
 
         /**
          * @brief Returns direct internal children of a node.
          * @complexity Range creation O(1); full iteration O(#children).
          */
-        ChildrenRange getChildren(index_t nodeId) const { 
-            return ChildrenRange(this, firstChild[(size_t) localOf(nodeId)]); 
-        }
+        ChildrenRange getChildren(index_t nodeId) const;
 
         /**
          * @brief Returns direct proper parts owned by a node.
          * @complexity Range creation O(1); full iteration O(#proper parts).
          */
-        ProperPartsRange getProperParts(index_t nodeId) const { 
-            return ProperPartsRange(this, properHead[(size_t) localOf(nodeId)]); 
-        }
+        ProperPartsRange getProperParts(index_t nodeId) const;
 
         /**
          * @brief Returns a post-order traversal from the current root.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        PostOrderNodeRange getPostOrderNodes() const { 
-            return PostOrderNodeRange(this, getRoot()); 
-        }
+        PostOrderNodeRange getPostOrderNodes() const;
 
         /**
          * @brief Returns a post-order traversal rooted at rootNodeId.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        PostOrderNodeRange getPostOrderNodes(index_t rootNodeId) const { 
-            return PostOrderNodeRange(this, rootNodeId); 
-        }
+        PostOrderNodeRange getPostOrderNodes(index_t rootNodeId) const;
 
         /**
          * @brief Returns a breadth-first traversal from the current root.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        BreadthFirstNodeRange getBreadthFirstNodes() const { 
-            return BreadthFirstNodeRange(this, getRoot()); 
-        }
+        BreadthFirstNodeRange getBreadthFirstNodes() const;
 
         /**
          * @brief Returns a breadth-first traversal rooted at rootNodeId.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        BreadthFirstNodeRange getBreadthFirstNodes(index_t rootNodeId) const { 
-            return BreadthFirstNodeRange(this, rootNodeId); 
-        }
+        BreadthFirstNodeRange getBreadthFirstNodes(index_t rootNodeId) const;
 
         /**
          * @brief Returns the path from nodeId to the root, both endpoints included.
          * @complexity Range creation O(1); full iteration O(path length).
          */
-        PathToRootRange getPathToRootNodes(index_t nodeId) const { 
-            return PathToRootRange(this, nodeId); 
-        }
+        PathToRootRange getPathToRootNodes(index_t nodeId) const;
 
         /**
          * @brief Returns the rooted subtree of nodeId in pre-order.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        SubtreeNodeRange getNodeSubtree(index_t nodeId) const { 
-            return SubtreeNodeRange(this, nodeId); 
-        }
+        SubtreeNodeRange getNodeSubtree(index_t nodeId) const;
 
         /**
          * @brief Returns descendants of nodeId in pre-order, excluding nodeId.
          * @complexity Range creation O(1); full iteration O(#returned nodes).
          */
-        DescendantNodeRange getDescendants(index_t nodeId) const { 
-            return DescendantNodeRange(this, nodeId); 
-        }
+        DescendantNodeRange getDescendants(index_t nodeId) const;
 
         /**
          * @brief Returns the parent of an internal node.
@@ -613,15 +598,6 @@ namespace hg {
          */
         index_t getNodeParent(index_t nodeId) const {
             return nodeParent[(size_t) localOf(nodeId)];
-        }
-
-        /**
-         * @brief Returns the altitude of an internal node.
-         * @warning nodeId must be an internal node.
-         * @complexity Time O(1), Space O(1).
-         */
-        altitude_t getNodeAltitude(index_t nodeId) const {
-            return nodeAltitude[(size_t) localOf(nodeId)];
         }
 
         /**
@@ -733,7 +709,6 @@ namespace hg {
             if (oldRoot != invalid_index && oldRoot != nodeId && isNode(oldRoot) && isAlive(oldRoot)) {
                 const auto oldRootLocalId = localOf(oldRoot);
                 nodeParent[(size_t) oldRootLocalId] = getNodeParent(oldRoot);
-                nodeAltitude[(size_t) oldRootLocalId] = getNodeAltitude(oldRoot);
             }
             rootNodeId = nodeId;
             const auto localId = localOf(nodeId);
@@ -746,7 +721,7 @@ namespace hg {
          * @return Global internal id, or invalid_index if there is no free slot.
          * @complexity Time O(1), Space O(1).
          */
-        index_t allocateNode(altitude_t altitudeValue) {
+        index_t allocateNode() {
             if (freeNodeSlots.empty()) {
                 return invalid_index;
             }
@@ -755,7 +730,6 @@ namespace hg {
             const auto nodeId = globalOf(localId);
             if (nodeId != invalid_index) {
                 nodeParent[(size_t) localId] = nodeId;
-                nodeAltitude[(size_t) localId] = altitudeValue;
                 firstChild[(size_t) localId] = invalid_index;
                 lastChild[(size_t) localId] = invalid_index;
                 nextSibling[(size_t) localId] = invalid_index;
@@ -789,7 +763,6 @@ namespace hg {
             properTail[(size_t) localId] = invalid_index;
             numProperPartsByNode[(size_t) localId] = 0;
             nodeParent[(size_t) localId] = invalid_index;
-            nodeAltitude[(size_t) localId] = altitude_t{};
             freeNodeSlots.push_back(localId);
             nodeStructureVersion++;
         }
@@ -808,7 +781,6 @@ namespace hg {
             const auto childLocalId = localOf(childId);
             if (releaseNodeFlag) {
                 nodeParent[(size_t) childLocalId] = invalid_index;
-                nodeAltitude[(size_t) childLocalId] = altitude_t{};
                 freeNodeSlots.push_back(childLocalId);
                 nodeStructureVersion++;
             } else {
@@ -966,8 +938,7 @@ namespace hg {
     /**
      * @brief Iterator over the direct internal children of a node.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::ChildrenIterator {
+    class DynamicComponentTree::ChildrenIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t currentLocal_ = invalid_index;
@@ -1011,8 +982,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of children.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::ChildrenRange {
+    class DynamicComponentTree::ChildrenRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t firstLocal_ = invalid_index;
@@ -1031,8 +1001,7 @@ namespace hg {
     /**
      * @brief Iterator over alive internal-node global ids.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::AliveNodeIterator {
+    class DynamicComponentTree::AliveNodeIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t current_ = invalid_index;
@@ -1088,8 +1057,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(I) to iterate, Space O(1), where I is the number of node slots.
      * @warning Lazy range. Invalidated if the node set changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::AliveNodeRange {
+    class DynamicComponentTree::AliveNodeRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t begin_ = 0;
@@ -1109,8 +1077,7 @@ namespace hg {
     /**
      * @brief Iterator over an internal rooted subtree in post-order.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::PostOrderNodeIterator {
+    class DynamicComponentTree::PostOrderNodeIterator {
     private:
         struct Item {
             index_t nodeId = invalid_index;
@@ -1184,8 +1151,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::PostOrderNodeRange {
+    class DynamicComponentTree::PostOrderNodeRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t rootNodeId_ = invalid_index;
@@ -1204,8 +1170,7 @@ namespace hg {
     /**
      * @brief Iterator over the path from a node to the root.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::PathToRootIterator {
+    class DynamicComponentTree::PathToRootIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t currentId_ = invalid_index;
@@ -1249,8 +1214,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(h) to iterate, Space O(1), where h is path length.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::PathToRootRange {
+    class DynamicComponentTree::PathToRootRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t startId_ = invalid_index;
@@ -1275,8 +1239,7 @@ namespace hg {
     /**
      * @brief Iterator over an internal rooted subtree in pre-order.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::SubtreeNodeIterator {
+    class DynamicComponentTree::SubtreeNodeIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         std::vector<index_t> stack_;
@@ -1336,8 +1299,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::SubtreeNodeRange {
+    class DynamicComponentTree::SubtreeNodeRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t rootNodeId_ = invalid_index;
@@ -1359,8 +1321,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::DescendantNodeRange {
+    class DynamicComponentTree::DescendantNodeRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t rootNodeId_ = invalid_index;
@@ -1385,8 +1346,7 @@ namespace hg {
     /**
      * @brief Iterator over the proper parts directly owned by a node.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::ProperPartsIterator {
+    class DynamicComponentTree::ProperPartsIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t current_ = invalid_index;
@@ -1430,8 +1390,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of proper parts.
      * @warning Lazy range. Invalidated if proper-part ownership changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::ProperPartsRange {
+    class DynamicComponentTree::ProperPartsRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t first_ = invalid_index;
@@ -1450,8 +1409,7 @@ namespace hg {
     /**
      * @brief Iterator over an internal rooted subtree in breadth-first order.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::BreadthFirstNodeIterator {
+    class DynamicComponentTree::BreadthFirstNodeIterator {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         std::vector<index_t> queue_;
@@ -1507,8 +1465,7 @@ namespace hg {
      * @complexity Time O(1) to create, O(S) to iterate, Space O(w), where S is subtree size and w the frontier width.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
-    template<typename altitude_t>
-    class DynamicComponentTree<altitude_t>::BreadthFirstNodeRange {
+    class DynamicComponentTree::BreadthFirstNodeRange {
     private:
         const DynamicComponentTree *tree_ = nullptr;
         index_t rootNodeId_ = invalid_index;
@@ -1524,4 +1481,44 @@ namespace hg {
         BreadthFirstNodeIterator end() const { return BreadthFirstNodeIterator(); }
     };
 
-} // namespace hg
+    inline DynamicComponentTree::AliveNodeRange DynamicComponentTree::getAliveNodeIds() const {
+        return AliveNodeRange(this, getNumTotalProperParts(), getGlobalIdSpaceSize());
+    }
+
+    inline DynamicComponentTree::ChildrenRange DynamicComponentTree::getChildren(index_t nodeId) const {
+        return ChildrenRange(this, firstChild[(size_t) localOf(nodeId)]);
+    }
+
+    inline DynamicComponentTree::ProperPartsRange DynamicComponentTree::getProperParts(index_t nodeId) const {
+        return ProperPartsRange(this, properHead[(size_t) localOf(nodeId)]);
+    }
+
+    inline DynamicComponentTree::PostOrderNodeRange DynamicComponentTree::getPostOrderNodes() const {
+        return PostOrderNodeRange(this, getRoot());
+    }
+
+    inline DynamicComponentTree::PostOrderNodeRange DynamicComponentTree::getPostOrderNodes(index_t rootNodeId) const {
+        return PostOrderNodeRange(this, rootNodeId);
+    }
+
+    inline DynamicComponentTree::BreadthFirstNodeRange DynamicComponentTree::getBreadthFirstNodes() const {
+        return BreadthFirstNodeRange(this, getRoot());
+    }
+
+    inline DynamicComponentTree::BreadthFirstNodeRange DynamicComponentTree::getBreadthFirstNodes(index_t rootNodeId) const {
+        return BreadthFirstNodeRange(this, rootNodeId);
+    }
+
+    inline DynamicComponentTree::PathToRootRange DynamicComponentTree::getPathToRootNodes(index_t nodeId) const {
+        return PathToRootRange(this, nodeId);
+    }
+
+    inline DynamicComponentTree::SubtreeNodeRange DynamicComponentTree::getNodeSubtree(index_t nodeId) const {
+        return SubtreeNodeRange(this, nodeId);
+    }
+
+    inline DynamicComponentTree::DescendantNodeRange DynamicComponentTree::getDescendants(index_t nodeId) const {
+        return DescendantNodeRange(this, nodeId);
+    }
+
+} // namespace hg::detail::hierarchy

--- a/include/higra/detail/hierarchy/dynamic_component_tree.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree.hpp
@@ -25,11 +25,11 @@ namespace hg::detail::hierarchy {
      *
      * The structure stores:
      *  - a mutable internal hierarchy restricted to internal nodes, and
-     *  - a distinct proper-part ownership structure for pixels/leaves.
+     *  - a distinct ownership structure for proper parts, each corresponding to an input graph vertex.
      *
      * Notation used in this class:
      *  - `N`: size of the global id space (`N = getGlobalIdSpaceSize()`).
-     *  - `L`: number of proper parts / pixels (`L = getNumTotalProperParts()`).
+     *  - `L`: number of proper parts (`L = getNumTotalProperParts()`).
      *  - `I`: number of node slots (`I = getNumInternalNodeSlots()`).
      *  - `C_component_tree`: cost of building a component tree with Higra
      *    (`component_tree_max_tree` or `component_tree_min_tree`), including sorting
@@ -55,7 +55,7 @@ namespace hg::detail::hierarchy {
      * Iterators/ranges provided by this class:
      *  - `getAliveNodeIds()`: linear range over all alive internal global ids `[L, N)`.
      *  - `getChildren(nodeId)`: direct internal children of `nodeId`.
-     *  - `getProperParts(nodeId)`: proper-part pixels directly owned by `nodeId`.
+     *  - `getProperParts(nodeId)`: proper parts directly owned by `nodeId`.
      *  - `getPostOrderNodes()`, `getPostOrderNodes(rootNodeId)`:
      *    internal hierarchy in post-order.
      *  - `getBreadthFirstNodes()`, `getBreadthFirstNodes(rootNodeId)`:
@@ -117,7 +117,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Appends a detached child at the back of a parent's child list.
          * @warning Caller must ensure detached child and valid relation.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void linkChildBack(index_t parentId, index_t childId) {
             const auto parentLocalId = localOf(parentId);
@@ -137,7 +137,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Unlinks an attached child from its parent child list.
          * @warning Caller must ensure attached state and non-root use.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void unlinkChild(index_t childId) {
             const auto childLocalId = localOf(childId);
@@ -166,7 +166,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Moves all proper parts owned by nodeB to nodeA.
          * @warning This is a low-level helper that assumes both nodes are valid and alive.
-         * @complexity Time O(k), Space O(1), where k is the number of moved proper parts.
+         * :Complexity: Time O(k), Space O(1), where k is the number of moved proper parts.
          */
         void moveProperPartsInBackend(index_t nodeA, index_t nodeB) {
             const auto localA = localOf(nodeA);
@@ -197,7 +197,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Detaches an internal node from its parent in the backend state.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void detachNodeInBackend(index_t nodeId) {
             unlinkChild(nodeId);
@@ -208,7 +208,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Releases an internal node slot in the backend state.
          * @warning Node must already be detached and contain no children/proper parts.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void releaseNodeSlot(index_t nodeId) {
             const auto localId = localOf(nodeId);
@@ -250,7 +250,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Initializes storage for a dynamic tree with the given number of leaves and node slots.
-         * @complexity Time O(L + I), Space O(L + I).
+         * :Complexity: Time O(L + I), Space O(L + I).
          */
         void initializeStorage(index_t numProperParts, index_t numInternalNodeSlots) {
             hg_assert(numProperParts > 0, "DynamicComponentTree must contain at least one proper part.");
@@ -280,7 +280,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Builds the dynamic tree from Higra parent arrays.
-         * @complexity Time O(N), Space O(N).
+         * :Complexity: Time O(N), Space O(N).
          */
         template<typename T1>
         void buildFromParent(const xt::xexpression<T1> &xparent, index_t numProperParts) {
@@ -336,7 +336,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Maps a global internal id to a local internal id.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t localOf(index_t nodeId) const {
             hg_assert(nodeId >= numTotalProperParts_ && nodeId < getGlobalIdSpaceSize(), "Node is not an internal node.");
@@ -345,7 +345,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Maps a local internal id to a global internal id.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t globalOf(index_t localId) const { 
             return localId + numTotalProperParts_; 
@@ -376,7 +376,7 @@ namespace hg::detail::hierarchy {
          * @brief Constructs a dynamic tree from parent arrays using Higra tree conventions.
          * @warning The parent array is expected to follow the Higra tree convention, with proper parts
          *          occupying the prefix `[0, L)`.
-         * @complexity Time O(N), Space O(N).
+         * :Complexity: Time O(N), Space O(N).
          */
         template<typename T1>
         explicit DynamicComponentTree(const xt::xexpression<T1> &xparent) {
@@ -385,7 +385,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Constructs a dynamic tree from a Higra tree.
-         * @complexity Time O(N), Space O(N).
+         * :Complexity: Time O(N), Space O(N).
          */
         explicit DynamicComponentTree(const tree &inputTree) {
             buildFromParent(inputTree.parents(), (index_t) inputTree.num_leaves());
@@ -395,7 +395,7 @@ namespace hg::detail::hierarchy {
          * @brief Resets this dynamic tree from parent arrays using Higra tree conventions.
          * @warning The parent array is expected to follow the Higra tree convention, with proper parts
          *          occupying the prefix `[0, L)`.
-         * @complexity Time O(N), Space O(N).
+         * :Complexity: Time O(N), Space O(N).
          */
         template<typename T1>
         void reset(const xt::xexpression<T1> &xparent) {
@@ -404,7 +404,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Resets this dynamic tree from a Higra tree.
-         * @complexity Time O(N), Space O(N).
+         * :Complexity: Time O(N), Space O(N).
          */
         void reset(const tree &inputTree) {
             buildFromParent(inputTree.parents(), (index_t) inputTree.num_leaves());
@@ -412,7 +412,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the number of internal-node slots, alive or free.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumInternalNodeSlots() const { 
             return numInternalNodeSlots_; 
@@ -420,7 +420,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the size of the global id space `[0, L + I)`.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getGlobalIdSpaceSize() const { 
             return numTotalProperParts_ + numInternalNodeSlots_; 
@@ -428,7 +428,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Counts alive leaf nodes in the internal hierarchy.
-         * @complexity Time O(I), Space O(1).
+         * :Complexity: Time O(I), Space O(1).
          */
         index_t getNumLeafNodes() const {
             index_t count = 0;
@@ -444,8 +444,8 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Returns the total number of proper parts (pixels) in the image domain.
-         * @complexity Time O(1), Space O(1).
+         * @brief Returns the total number of proper parts, one for each input graph vertex.
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumTotalProperParts() const { 
             return numTotalProperParts_; 
@@ -453,7 +453,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the number of alive internal nodes.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumNodes() const { 
             return numInternalNodeSlots_ - (index_t) freeNodeSlots.size(); 
@@ -461,15 +461,15 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Tests whether a global id refers to an internal node slot.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         bool isNode(index_t nodeId) const { 
             return nodeId >= numTotalProperParts_ && nodeId < getGlobalIdSpaceSize(); 
         }
 
         /**
-         * @brief Tests whether a global id refers to a proper part / pixel.
-         * @complexity Time O(1), Space O(1).
+         * @brief Tests whether a global id refers to a proper part.
+         * :Complexity: Time O(1), Space O(1).
          */
         bool isProperPart(index_t nodeId) const { 
             return nodeId >= 0 && nodeId < numTotalProperParts_; 
@@ -477,7 +477,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the current root id.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getRoot() const { 
             return rootNodeId; 
@@ -485,7 +485,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Tests whether a node is the current root.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         bool isRoot(index_t nodeId) const { 
             return nodeId == rootNodeId; 
@@ -493,7 +493,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the number of free internal-node slots currently available for reuse.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumFreeNodeSlots() const { 
             return (index_t) freeNodeSlots.size(); 
@@ -501,7 +501,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the number of direct children of an internal node.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumChildren(index_t nodeId) const { 
             return numChildrenByNode[(size_t) localOf(nodeId)];
@@ -510,7 +510,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Returns the first direct child of an internal node.
          * @return Global child id, or `invalid_index` when `nodeId` has no child.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getFirstChild(index_t nodeId) const {
             const auto childLocalId = firstChild[(size_t) localOf(nodeId)];
@@ -520,7 +520,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Returns the next sibling of an internal node.
          * @return Global sibling id, or `invalid_index` when `nodeId` is the last sibling.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNextSibling(index_t nodeId) const {
             const auto siblingLocalId = nextSibling[(size_t) localOf(nodeId)];
@@ -529,7 +529,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Tests whether an internal node has no internal children.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         bool isLeaf(index_t nodeId) const { 
             return firstChild[(size_t) localOf(nodeId)] == invalid_index; 
@@ -537,7 +537,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the number of direct proper parts currently owned by a given node.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNumProperParts(index_t nodeId) const { 
             return numProperPartsByNode[(size_t) localOf(nodeId)];
@@ -545,7 +545,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Tests whether childId is currently a direct child of parentId.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         bool hasChild(index_t parentId, index_t childId) const { 
             return getNodeParent(childId) == parentId;
@@ -553,68 +553,68 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns all alive internal nodes.
-         * @complexity Range creation O(1); full iteration O(I).
+         * :Complexity: Range creation O(1); full iteration O(I).
          */
         AliveNodeRange getAliveNodeIds() const;
 
         /**
          * @brief Returns direct internal children of a node.
-         * @complexity Range creation O(1); full iteration O(#children).
+         * :Complexity: Range creation O(1); full iteration O(#children).
          */
         ChildrenRange getChildren(index_t nodeId) const;
 
         /**
          * @brief Returns direct proper parts owned by a node.
-         * @complexity Range creation O(1); full iteration O(#proper parts).
+         * :Complexity: Range creation O(1); full iteration O(#proper parts).
          */
         ProperPartsRange getProperParts(index_t nodeId) const;
 
         /**
          * @brief Returns a post-order traversal from the current root.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         PostOrderNodeRange getPostOrderNodes() const;
 
         /**
          * @brief Returns a post-order traversal rooted at rootNodeId.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         PostOrderNodeRange getPostOrderNodes(index_t rootNodeId) const;
 
         /**
          * @brief Returns a breadth-first traversal from the current root.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         BreadthFirstNodeRange getBreadthFirstNodes() const;
 
         /**
          * @brief Returns a breadth-first traversal rooted at rootNodeId.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         BreadthFirstNodeRange getBreadthFirstNodes(index_t rootNodeId) const;
 
         /**
          * @brief Returns the path from nodeId to the root, both endpoints included.
-         * @complexity Range creation O(1); full iteration O(path length).
+         * :Complexity: Range creation O(1); full iteration O(path length).
          */
         PathToRootRange getPathToRootNodes(index_t nodeId) const;
 
         /**
          * @brief Returns the rooted subtree of nodeId in pre-order.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         SubtreeNodeRange getNodeSubtree(index_t nodeId) const;
 
         /**
          * @brief Returns descendants of nodeId in pre-order, excluding nodeId.
-         * @complexity Range creation O(1); full iteration O(#returned nodes).
+         * :Complexity: Range creation O(1); full iteration O(#returned nodes).
          */
         DescendantNodeRange getDescendants(index_t nodeId) const;
 
         /**
          * @brief Returns the parent of an internal node.
          * @warning nodeId must be an internal node.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getNodeParent(index_t nodeId) const {
             return nodeParent[(size_t) localOf(nodeId)];
@@ -622,7 +622,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Returns the current owner / smallest component of a proper part.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t getSmallestComponent(index_t pixelId) const {
             if (pixelId >= 0 && pixelId < this->getNumTotalProperParts()) {
@@ -633,7 +633,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Tests whether an internal node slot is alive.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         bool isAlive(index_t nodeId) const {
             if (!isNode(nodeId)) {
@@ -644,7 +644,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Moves one direct proper part from sourceNodeId to targetNodeId.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void moveProperPart(index_t targetNodeId, index_t sourceNodeId, index_t pixelId) {
             const auto targetLocalId = localOf(targetNodeId);
@@ -684,7 +684,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Moves all direct proper parts of nodeB to nodeA.
-         * @complexity Time O(k), Space O(1), where k is the number of moved proper parts.
+         * :Complexity: Time O(k), Space O(1), where k is the number of moved proper parts.
          */
         void moveProperParts(index_t nodeA, index_t nodeB) {
             const auto localA = localOf(nodeA);
@@ -718,7 +718,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Sets nodeId as the tree root.
          * @warning If nodeId is attached, it is detached first.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void setRoot(index_t nodeId) {
             const auto oldRoot = getRoot();
@@ -739,7 +739,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Allocates a released internal-node slot (LIFO free list).
          * @return Global internal id, or invalid_index if there is no free slot.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         index_t allocateNode() {
             if (freeNodeSlots.empty()) {
@@ -766,7 +766,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Releases an internal-node slot back to the free list.
          * @warning Node must be detached and empty.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void releaseNode(index_t nodeId) {
             hg_assert(isAlive(nodeId), "releaseNode expects an alive internal node.");
@@ -789,7 +789,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Removes a direct child from a parent, optionally releasing the child slot.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void removeChild(index_t parentId, index_t childId, bool releaseNodeFlag) {
             const auto childWasAlive = isNode(childId) && isAlive(childId);
@@ -811,7 +811,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Attaches a detached node as the last child of parentId.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void attachNode(index_t parentId, index_t nodeId) {
             linkChildBack(parentId, nodeId);
@@ -822,7 +822,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Detaches an attached node from its parent.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void detachNode(index_t nodeId) {
             unlinkChild(nodeId);
@@ -833,7 +833,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Moves an attached node under a new parent.
-         * @complexity Time O(1), Space O(1).
+         * :Complexity: Time O(1), Space O(1).
          */
         void moveNode(index_t nodeId, index_t newParentId) {
             const auto oldParentId = getNodeParent(nodeId);
@@ -848,7 +848,7 @@ namespace hg::detail::hierarchy {
 
         /**
          * @brief Moves all direct children of sourceId under parentId.
-         * @complexity Time O(k), Space O(1), where k is the number of moved children.
+         * :Complexity: Time O(k), Space O(1), where k is the number of moved children.
          */
         void moveChildren(index_t parentId, index_t sourceId) {
             const auto parentLocalId = localOf(parentId);
@@ -886,7 +886,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Removes a subtree and absorbs its direct proper parts into the parent.
          * @warning nodeId must be a non-root alive internal node.
-         * @complexity Time O(s + p), Space O(1), where s is the number of nodes in the
+         * :Complexity: Time O(s + p), Space O(1), where s is the number of nodes in the
          *             subtree and p the number of proper parts owned by those nodes.
          */
         void pruneNode(index_t nodeId) {
@@ -930,7 +930,7 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Merges a node into its parent, reattaching direct children and proper parts.
          * @warning nodeId must be a non-root alive internal node.
-         * @complexity Time O(c + p), Space O(1), where c is the number of direct children and
+         * :Complexity: Time O(c + p), Space O(1), where c is the number of direct children and
          *             p the number of direct proper parts of nodeId.
          */
         void mergeNodeIntoParent(index_t nodeId) {
@@ -998,8 +998,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over the direct internal children of a node.
-     * @usage `for (auto n : tree.getChildren(nodeId)) { ... }`
-     * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of children.
+     * :Example: `for (auto n : tree.getChildren(nodeId)) { ... }`
+     * :Complexity: Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of children.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::ChildrenRange {
@@ -1073,8 +1073,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over alive internal-node global ids.
-     * @usage `for (auto n : tree.getAliveNodeIds()) { ... }`
-     * @complexity Time O(1) to create, O(I) to iterate, Space O(1), where I is the number of node slots.
+     * :Example: `for (auto n : tree.getAliveNodeIds()) { ... }`
+     * :Complexity: Time O(1) to create, O(I) to iterate, Space O(1), where I is the number of node slots.
      * @warning Lazy range. Invalidated if the node set changes during iteration.
      */
     class DynamicComponentTree::AliveNodeRange {
@@ -1167,8 +1167,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over an internal rooted subtree in post-order.
-     * @usage `for (auto n : tree.getPostOrderNodes()) { ... }`
-     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * :Example: `for (auto n : tree.getPostOrderNodes()) { ... }`
+     * :Complexity: Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::PostOrderNodeRange {
@@ -1230,8 +1230,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over the path from a node to the root.
-     * @usage `for (auto n : tree.getPathToRootNodes(nodeId)) { ... }`
-     * @complexity Time O(1) to create, O(h) to iterate, Space O(1), where h is path length.
+     * :Example: `for (auto n : tree.getPathToRootNodes(nodeId)) { ... }`
+     * :Complexity: Time O(1) to create, O(h) to iterate, Space O(1), where h is path length.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::PathToRootRange {
@@ -1315,8 +1315,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over an internal rooted subtree in pre-order.
-     * @usage `for (auto n : tree.getNodeSubtree(nodeId)) { ... }`
-     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * :Example: `for (auto n : tree.getNodeSubtree(nodeId)) { ... }`
+     * :Complexity: Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::SubtreeNodeRange {
@@ -1337,8 +1337,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over the descendants of a node, excluding the node itself.
-     * @usage `for (auto n : tree.getDescendants(nodeId)) { ... }`
-     * @complexity Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
+     * :Example: `for (auto n : tree.getDescendants(nodeId)) { ... }`
+     * :Complexity: Time O(1) to create, O(S) to iterate, Space O(h), where S is subtree size and h its height.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::DescendantNodeRange {
@@ -1406,8 +1406,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over the proper parts directly owned by a node.
-     * @usage `for (auto p : tree.getProperParts(nodeId)) { ... }`
-     * @complexity Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of proper parts.
+     * :Example: `for (auto p : tree.getProperParts(nodeId)) { ... }`
+     * :Complexity: Time O(1) to create, O(k) to iterate, Space O(1), where k is the number of proper parts.
      * @warning Lazy range. Invalidated if proper-part ownership changes during iteration.
      */
     class DynamicComponentTree::ProperPartsRange {
@@ -1481,8 +1481,8 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Range over an internal rooted subtree in breadth-first order.
-     * @usage `for (auto n : tree.getBreadthFirstNodes()) { ... }`
-     * @complexity Time O(1) to create, O(S) to iterate, Space O(w), where S is subtree size and w the frontier width.
+     * :Example: `for (auto n : tree.getBreadthFirstNodes()) { ... }`
+     * :Complexity: Time O(1) to create, O(S) to iterate, Space O(w), where S is subtree size and w the frontier width.
      * @warning Lazy range. Invalidated if the tree topology changes during iteration.
      */
     class DynamicComponentTree::BreadthFirstNodeRange {

--- a/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
@@ -1,0 +1,224 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+
+namespace hg::detail::hierarchy {
+
+    /**
+     * @brief Base class for dynamic-tree scalar attribute computers.
+     * @details The class defines the bottom-up reduction protocol through
+     * `preProcessing`, `mergeProcessing`, and `postProcessing`, and provides the
+     * execution helpers `computeAttribute(...)` and `computeAttributeOnNode(...)`.
+     * Released dynamic-tree slots remain addressable, so buffers are sized on the
+     * full global id space.
+     */
+    template<typename value_t = double>
+    class DynamicComponentTreeAttributeComputer {
+    public:
+        using tree_type = DynamicComponentTree;
+        using buffer_type = std::vector<value_t>;
+
+        virtual ~DynamicComponentTreeAttributeComputer() = default;
+
+        virtual void resize(const tree_type &tree, buffer_type &buffer) const {
+            buffer.resize((size_t) tree.getGlobalIdSpaceSize(), value_t{});
+        }
+
+        virtual void preProcessing(index_t nodeId, const tree_type &tree, buffer_type &buffer) const = 0;
+
+        virtual void mergeProcessing(index_t parentId, index_t childId, const tree_type &tree, buffer_type &buffer) const = 0;
+
+        virtual void postProcessing(index_t nodeId, const tree_type &tree, buffer_type &buffer) const = 0;
+
+        /**
+         * @brief Computes the attribute on the full tree by a bottom-up pass.
+         */
+        void computeAttribute(const tree_type &tree, buffer_type &buffer) const {
+            resize(tree, buffer);
+            for (auto nodeId: tree.getPostOrderNodes()) {
+                preProcessing(nodeId, tree, buffer);
+                for (auto childId: tree.getChildren(nodeId)) {
+                    mergeProcessing(nodeId, childId, tree, buffer);
+                }
+                postProcessing(nodeId, tree, buffer);
+            }
+        }
+
+        /**
+         * @brief Recomputes one node assuming its direct children are already up to date.
+         */
+        void computeAttributeOnNode(const tree_type &tree, index_t nodeId, buffer_type &buffer) const {
+            preProcessing(nodeId, tree, buffer);
+            for (auto childId: tree.getChildren(nodeId)) {
+                mergeProcessing(nodeId, childId, tree, buffer);
+            }
+            postProcessing(nodeId, tree, buffer);
+        }
+    };
+
+    /**
+     * @brief Incremental area computer for the internal dynamic component tree.
+     * @details Computes the canonical increasing area attribute by counting the
+     * proper parts directly owned by each node and accumulating child areas. The
+     * single-node refresh contract is therefore straightforward: once child areas are
+     * current, recomputing a parent requires only its direct proper-part count and the
+     * cached values of its direct children.
+     */
+    template<typename value_t = double>
+    class DynamicComponentTreeAreaAttributeComputer : public DynamicComponentTreeAttributeComputer<value_t> {
+    public:
+        using tree_type = typename DynamicComponentTreeAttributeComputer<value_t>::tree_type;
+        using buffer_type = typename DynamicComponentTreeAttributeComputer<value_t>::buffer_type;
+
+        void preProcessing(index_t nodeId, const tree_type &tree, buffer_type &buffer) const override {
+            buffer[(size_t) nodeId] = (value_t) tree.getNumProperParts(nodeId);
+        }
+
+        void mergeProcessing(index_t parentId, index_t childId, const tree_type &, buffer_type &buffer) const override {
+            buffer[(size_t) parentId] += buffer[(size_t) childId];
+        }
+
+        void postProcessing(index_t, const tree_type &, buffer_type &) const override { }
+    };
+
+
+    /**
+     * @brief Scalar measures derivable from an axis-aligned bounding box.
+     */
+    enum class DynamicComponentTreeBoundingBoxMeasure {
+        width,
+        height,
+        diagonal_length
+    };
+
+    /**
+     * @brief Incremental bounding-box attribute computer for dynamic component trees.
+     * @details The constructor receives a pixel-to-point functor so the tree backend
+     * stays independent from any specific image embedding. The resulting scalar can
+     * be the box width, height, or diagonal length.
+     *
+     * The computer keeps per-node mutable auxiliary buffers (`xmin`, `xmax`, `ymin`,
+     * `ymax`, `empty`) so `preProcessing`, `mergeProcessing`, and `postProcessing` can
+     * share intermediate state. Consequently, a single-node refresh with
+     * `computeAttributeOnNode(...)` is valid only when applied bottom-up on the affected
+     * path, after all edited children have themselves been refreshed.
+     */
+    template<typename pixel_to_point_t, typename value_t = double>
+    class DynamicComponentTreeBoundingBoxAttributeComputer : public DynamicComponentTreeAttributeComputer<value_t> {
+    public:
+        using tree_type = typename DynamicComponentTreeAttributeComputer<value_t>::tree_type;
+        using buffer_type = typename DynamicComponentTreeAttributeComputer<value_t>::buffer_type;
+
+        explicit DynamicComponentTreeBoundingBoxAttributeComputer(pixel_to_point_t pixelToPoint,
+                                                                  DynamicComponentTreeBoundingBoxMeasure measure = DynamicComponentTreeBoundingBoxMeasure::diagonal_length)
+            : pixelToPoint(std::move(pixelToPoint)), measure(measure) {
+        }
+
+        /**
+         * @brief Resizes the output and auxiliary buffers on the full dynamic-tree id space.
+         */
+        void resize(const tree_type &tree, buffer_type &buffer) const override {
+            DynamicComponentTreeAttributeComputer<value_t>::resize(tree, buffer);
+            const auto size = (size_t) tree.getGlobalIdSpaceSize();
+            xmin.resize(size, 0);
+            xmax.resize(size, 0);
+            ymin.resize(size, 0);
+            ymax.resize(size, 0);
+            empty.resize(size, true);
+        }
+
+        /**
+         * @brief Initializes the node-local bounding box from its direct proper parts.
+         */
+        void preProcessing(index_t nodeId, const tree_type &tree, buffer_type &) const override {
+            xmin[(size_t) nodeId] = std::numeric_limits<index_t>::max();
+            xmax[(size_t) nodeId] = std::numeric_limits<index_t>::lowest();
+            ymin[(size_t) nodeId] = std::numeric_limits<index_t>::max();
+            ymax[(size_t) nodeId] = std::numeric_limits<index_t>::lowest();
+            empty[(size_t) nodeId] = true;
+
+            for (auto pixelId: tree.getProperParts(nodeId)) {
+                const auto point = pixelToPoint(pixelId);
+                const auto y = (index_t) point.first;
+                const auto x = (index_t) point.second;
+                xmin[(size_t) nodeId] = std::min(xmin[(size_t) nodeId], x);
+                xmax[(size_t) nodeId] = std::max(xmax[(size_t) nodeId], x);
+                ymin[(size_t) nodeId] = std::min(ymin[(size_t) nodeId], y);
+                ymax[(size_t) nodeId] = std::max(ymax[(size_t) nodeId], y);
+                empty[(size_t) nodeId] = false;
+            }
+        }
+
+        /**
+         * @brief Expands the parent bounding box with one already-computed child box.
+         */
+        void mergeProcessing(index_t parentId, index_t childId, const tree_type &, buffer_type &) const override {
+            if (empty[(size_t) childId]) {
+                return;
+            }
+            if (empty[(size_t) parentId]) {
+                xmin[(size_t) parentId] = xmin[(size_t) childId];
+                xmax[(size_t) parentId] = xmax[(size_t) childId];
+                ymin[(size_t) parentId] = ymin[(size_t) childId];
+                ymax[(size_t) parentId] = ymax[(size_t) childId];
+                empty[(size_t) parentId] = false;
+                return;
+            }
+
+            xmin[(size_t) parentId] = std::min(xmin[(size_t) parentId], xmin[(size_t) childId]);
+            xmax[(size_t) parentId] = std::max(xmax[(size_t) parentId], xmax[(size_t) childId]);
+            ymin[(size_t) parentId] = std::min(ymin[(size_t) parentId], ymin[(size_t) childId]);
+            ymax[(size_t) parentId] = std::max(ymax[(size_t) parentId], ymax[(size_t) childId]);
+        }
+
+        /**
+         * @brief Converts the accumulated box extents into the requested scalar measure.
+         */
+        void postProcessing(index_t nodeId, const tree_type &, buffer_type &buffer) const override {
+            if (empty[(size_t) nodeId]) {
+                buffer[(size_t) nodeId] = value_t{};
+                return;
+            }
+
+            const auto width = (value_t) (xmax[(size_t) nodeId] - xmin[(size_t) nodeId] + 1);
+            const auto height = (value_t) (ymax[(size_t) nodeId] - ymin[(size_t) nodeId] + 1);
+
+            switch (measure) {
+                case DynamicComponentTreeBoundingBoxMeasure::width:
+                    buffer[(size_t) nodeId] = width;
+                    break;
+                case DynamicComponentTreeBoundingBoxMeasure::height:
+                    buffer[(size_t) nodeId] = height;
+                    break;
+                case DynamicComponentTreeBoundingBoxMeasure::diagonal_length:
+                    buffer[(size_t) nodeId] = (value_t) std::sqrt(width * width + height * height);
+                    break;
+            }
+        }
+
+    private:
+        pixel_to_point_t pixelToPoint;
+        DynamicComponentTreeBoundingBoxMeasure measure;
+        mutable std::vector<index_t> xmin;
+        mutable std::vector<index_t> xmax;
+        mutable std::vector<index_t> ymin;
+        mutable std::vector<index_t> ymax;
+        mutable std::vector<bool> empty;
+    };
+
+} // namespace hg::detail::hierarchy

--- a/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cmath>
 #include <limits>
 #include <utility>
@@ -44,6 +45,15 @@ namespace hg::detail::hierarchy {
         virtual void mergeProcessing(index_t parentId, index_t childId, const tree_type &tree, buffer_type &buffer) const = 0;
 
         virtual void postProcessing(index_t nodeId, const tree_type &tree, buffer_type &buffer) const = 0;
+
+        /**
+         * @brief Incremental-update hooks called by the tree on structural edits.
+         * @details The default implementations are no-ops so concrete computers can
+         * override only the events they actually exploit.
+         */
+        virtual void onMoveProperParts(index_t, index_t, const tree_type &) const { }
+        virtual void onMoveProperPart(index_t, index_t, index_t, const tree_type &) const { }
+        virtual void onNodeRemoved(index_t, const tree_type &) const { }
 
         /**
          * @brief Computes the attribute on the full tree by a bottom-up pass.
@@ -112,9 +122,9 @@ namespace hg::detail::hierarchy {
      * stays independent from any specific image embedding. The resulting scalar can
      * be the box width, height, or diagonal length.
      *
-     * The computer keeps per-node mutable auxiliary buffers (`xmin`, `xmax`, `ymin`,
-     * `ymax`, `empty`) so `preProcessing`, `mergeProcessing`, and `postProcessing` can
-     * share intermediate state. Consequently, a single-node refresh with
+     * The computer keeps per-node mutable auxiliary buffers: `local_` stores the box of
+     * direct proper parts together with extremum multiplicities, while `subtree_` stores
+     * the accumulated box after child merges. Consequently, a single-node refresh with
      * `computeAttributeOnNode(...)` is valid only when applied bottom-up on the affected
      * path, after all edited children have themselves been refreshed.
      */
@@ -124,6 +134,229 @@ namespace hg::detail::hierarchy {
         using tree_type = typename DynamicComponentTreeAttributeComputer<value_t>::tree_type;
         using buffer_type = typename DynamicComponentTreeAttributeComputer<value_t>::buffer_type;
 
+    private:
+        /**
+         * @brief Cached subtree box produced during the current bottom-up reduction.
+         */
+        struct DynamicComponentTreeBoundingBoxState {
+            index_t xmin = 0;
+            index_t xmax = -1;
+            index_t ymin = 0;
+            index_t ymax = -1;
+            std::uint8_t empty = 1;
+        };
+
+        /**
+         * @brief Cached box of direct proper parts plus enough metadata for local updates.
+         */
+        struct DynamicComponentTreeBoundingBoxLocalSummary {
+            index_t xmin = 0;
+            index_t xmax = -1;
+            index_t ymin = 0;
+            index_t ymax = -1;
+            index_t xminCount = 0;
+            index_t xmaxCount = 0;
+            index_t yminCount = 0;
+            index_t ymaxCount = 0;
+            index_t properPartCount = 0;
+            std::uint8_t empty = 1;
+            std::uint8_t dirty = 1;
+        };
+
+        pixel_to_point_t pixelToPoint;
+        DynamicComponentTreeBoundingBoxMeasure measure;
+        mutable std::vector<DynamicComponentTreeBoundingBoxLocalSummary> local_;
+        mutable std::vector<DynamicComponentTreeBoundingBoxState> subtree_;
+
+        /**
+         * @brief Restores an empty local box and clears all extremum multiplicities.
+         */
+        void resetLocalBox(DynamicComponentTreeBoundingBoxLocalSummary &local) const {
+            local.xmin = 0;
+            local.xmax = -1;
+            local.ymin = 0;
+            local.ymax = -1;
+            local.xminCount = 0;
+            local.xmaxCount = 0;
+            local.yminCount = 0;
+            local.ymaxCount = 0;
+            local.properPartCount = 0;
+            local.empty = 1;
+        }
+
+        /**
+         * @brief Resets one node-local cache entry and marks it as already synchronized.
+         */
+        void resetLocalSummary(index_t nodeId) const {
+            auto &local = local_[(size_t) nodeId];
+            resetLocalBox(local);
+            local.dirty = 0;
+        }
+
+        /**
+         * @brief Clears the subtree cache associated with one node.
+         */
+        void resetSubtreeSummary(index_t nodeId) const {
+            auto &subtree = subtree_[(size_t) nodeId];
+            subtree.xmin = 0;
+            subtree.xmax = -1;
+            subtree.ymin = 0;
+            subtree.ymax = -1;
+            subtree.empty = 1;
+        }
+
+        /**
+         * @brief Enlarges a local box with one proper part and updates extremum counts.
+         */
+        void expandLocalBoxWithPixel(DynamicComponentTreeBoundingBoxLocalSummary &local, index_t pixelId) const {
+            const auto point = pixelToPoint(pixelId);
+            const auto y = (index_t) point.first;
+            const auto x = (index_t) point.second;
+            if (local.empty) {
+                local.xmin = x;
+                local.xmax = x;
+                local.ymin = y;
+                local.ymax = y;
+                local.xminCount = 1;
+                local.xmaxCount = 1;
+                local.yminCount = 1;
+                local.ymaxCount = 1;
+                local.empty = 0;
+                return;
+            }
+
+            if (x < local.xmin) {
+                local.xmin = x;
+                local.xminCount = 1;
+            } else if (x == local.xmin) {
+                ++local.xminCount;
+            }
+
+            if (x > local.xmax) {
+                local.xmax = x;
+                local.xmaxCount = 1;
+            } else if (x == local.xmax) {
+                ++local.xmaxCount;
+            }
+
+            if (y < local.ymin) {
+                local.ymin = y;
+                local.yminCount = 1;
+            } else if (y == local.ymin) {
+                ++local.yminCount;
+            }
+
+            if (y > local.ymax) {
+                local.ymax = y;
+                local.ymaxCount = 1;
+            } else if (y == local.ymax) {
+                ++local.ymaxCount;
+            }
+        }
+
+        /**
+         * @brief Rebuilds the local summary from the current proper parts of the node.
+         */
+        void rebuildLocalBox(index_t nodeId, const tree_type &tree) const {
+            auto &local = local_[(size_t) nodeId];
+            resetLocalBox(local);
+            for (auto pixelId: tree.getProperParts(nodeId)) {
+                expandLocalBoxWithPixel(local, pixelId);
+            }
+            local.properPartCount = tree.getNumProperParts(nodeId);
+            local.dirty = 0;
+        }
+
+        /**
+         * @brief Lazily refreshes the local summary when a previous edit invalidated it.
+         */
+        void ensureLocalSummary(index_t nodeId, const tree_type &tree) const {
+            auto &local = local_[(size_t) nodeId];
+            const auto properPartCount = tree.getNumProperParts(nodeId);
+            if (!local.dirty && local.properPartCount == properPartCount) {
+                return;
+            }
+            rebuildLocalBox(nodeId, tree);
+        }
+
+        /**
+         * @brief Seeds the subtree cache of a node with its own local bounding box.
+         */
+        void copyLocalToSubtree(index_t nodeId) const {
+            const auto &local = local_[(size_t) nodeId];
+            auto &subtree = subtree_[(size_t) nodeId];
+            subtree.xmin = local.xmin;
+            subtree.xmax = local.xmax;
+            subtree.ymin = local.ymin;
+            subtree.ymax = local.ymax;
+            subtree.empty = local.empty;
+        }
+
+        /**
+         * @brief Unions a child subtree box into an accumulated parent subtree box.
+         */
+        void mergeSubtreeStates(DynamicComponentTreeBoundingBoxState &target, const DynamicComponentTreeBoundingBoxState &source) const {
+            if (source.empty) {
+                return;
+            }
+            if (target.empty) {
+                target = source;
+                return;
+            }
+            target.xmin = std::min(target.xmin, source.xmin);
+            target.xmax = std::max(target.xmax, source.xmax);
+            target.ymin = std::min(target.ymin, source.ymin);
+            target.ymax = std::max(target.ymax, source.ymax);
+            target.empty = 0;
+        }
+
+        /**
+         * @brief Merges two local summaries after moving all proper parts from source to target.
+         */
+        void mergeLocalBoxes(DynamicComponentTreeBoundingBoxLocalSummary &target, const DynamicComponentTreeBoundingBoxLocalSummary &source) const {
+            if (source.empty) {
+                return;
+            }
+
+            if (target.empty) {
+                target = source;
+                return;
+            }
+
+            if (source.xmin < target.xmin) {
+                target.xmin = source.xmin;
+                target.xminCount = source.xminCount;
+            } else if (source.xmin == target.xmin) {
+                target.xminCount += source.xminCount;
+            }
+
+            if (source.xmax > target.xmax) {
+                target.xmax = source.xmax;
+                target.xmaxCount = source.xmaxCount;
+            } else if (source.xmax == target.xmax) {
+                target.xmaxCount += source.xmaxCount;
+            }
+
+            if (source.ymin < target.ymin) {
+                target.ymin = source.ymin;
+                target.yminCount = source.yminCount;
+            } else if (source.ymin == target.ymin) {
+                target.yminCount += source.yminCount;
+            }
+
+            if (source.ymax > target.ymax) {
+                target.ymax = source.ymax;
+                target.ymaxCount = source.ymaxCount;
+            } else if (source.ymax == target.ymax) {
+                target.ymaxCount += source.ymaxCount;
+            }
+
+            target.properPartCount += source.properPartCount;
+            target.empty = 0;
+            target.dirty = 0;
+        }
+
+    public:
         explicit DynamicComponentTreeBoundingBoxAttributeComputer(pixel_to_point_t pixelToPoint,
                                                                   DynamicComponentTreeBoundingBoxMeasure measure = DynamicComponentTreeBoundingBoxMeasure::diagonal_length)
             : pixelToPoint(std::move(pixelToPoint)), measure(measure) {
@@ -135,68 +368,37 @@ namespace hg::detail::hierarchy {
         void resize(const tree_type &tree, buffer_type &buffer) const override {
             DynamicComponentTreeAttributeComputer<value_t>::resize(tree, buffer);
             const auto size = (size_t) tree.getGlobalIdSpaceSize();
-            xmin.resize(size, 0);
-            xmax.resize(size, 0);
-            ymin.resize(size, 0);
-            ymax.resize(size, 0);
-            empty.resize(size, true);
+            local_.resize(size);
+            subtree_.resize(size);
         }
 
         /**
          * @brief Initializes the node-local bounding box from its direct proper parts.
          */
         void preProcessing(index_t nodeId, const tree_type &tree, buffer_type &) const override {
-            xmin[(size_t) nodeId] = std::numeric_limits<index_t>::max();
-            xmax[(size_t) nodeId] = std::numeric_limits<index_t>::lowest();
-            ymin[(size_t) nodeId] = std::numeric_limits<index_t>::max();
-            ymax[(size_t) nodeId] = std::numeric_limits<index_t>::lowest();
-            empty[(size_t) nodeId] = true;
-
-            for (auto pixelId: tree.getProperParts(nodeId)) {
-                const auto point = pixelToPoint(pixelId);
-                const auto y = (index_t) point.first;
-                const auto x = (index_t) point.second;
-                xmin[(size_t) nodeId] = std::min(xmin[(size_t) nodeId], x);
-                xmax[(size_t) nodeId] = std::max(xmax[(size_t) nodeId], x);
-                ymin[(size_t) nodeId] = std::min(ymin[(size_t) nodeId], y);
-                ymax[(size_t) nodeId] = std::max(ymax[(size_t) nodeId], y);
-                empty[(size_t) nodeId] = false;
-            }
+            ensureLocalSummary(nodeId, tree);
+            copyLocalToSubtree(nodeId);
         }
 
         /**
          * @brief Expands the parent bounding box with one already-computed child box.
          */
         void mergeProcessing(index_t parentId, index_t childId, const tree_type &, buffer_type &) const override {
-            if (empty[(size_t) childId]) {
-                return;
-            }
-            if (empty[(size_t) parentId]) {
-                xmin[(size_t) parentId] = xmin[(size_t) childId];
-                xmax[(size_t) parentId] = xmax[(size_t) childId];
-                ymin[(size_t) parentId] = ymin[(size_t) childId];
-                ymax[(size_t) parentId] = ymax[(size_t) childId];
-                empty[(size_t) parentId] = false;
-                return;
-            }
-
-            xmin[(size_t) parentId] = std::min(xmin[(size_t) parentId], xmin[(size_t) childId]);
-            xmax[(size_t) parentId] = std::max(xmax[(size_t) parentId], xmax[(size_t) childId]);
-            ymin[(size_t) parentId] = std::min(ymin[(size_t) parentId], ymin[(size_t) childId]);
-            ymax[(size_t) parentId] = std::max(ymax[(size_t) parentId], ymax[(size_t) childId]);
+            mergeSubtreeStates(subtree_[(size_t) parentId], subtree_[(size_t) childId]);
         }
 
         /**
          * @brief Converts the accumulated box extents into the requested scalar measure.
          */
         void postProcessing(index_t nodeId, const tree_type &, buffer_type &buffer) const override {
-            if (empty[(size_t) nodeId]) {
+            const auto &subtree = subtree_[(size_t) nodeId];
+            if (subtree.empty) {
                 buffer[(size_t) nodeId] = value_t{};
                 return;
             }
 
-            const auto width = (value_t) (xmax[(size_t) nodeId] - xmin[(size_t) nodeId] + 1);
-            const auto height = (value_t) (ymax[(size_t) nodeId] - ymin[(size_t) nodeId] + 1);
+            const auto width = (value_t) (subtree.xmax - subtree.xmin + 1);
+            const auto height = (value_t) (subtree.ymax - subtree.ymin + 1);
 
             switch (measure) {
                 case DynamicComponentTreeBoundingBoxMeasure::width:
@@ -211,14 +413,94 @@ namespace hg::detail::hierarchy {
             }
         }
 
-    private:
-        pixel_to_point_t pixelToPoint;
-        DynamicComponentTreeBoundingBoxMeasure measure;
-        mutable std::vector<index_t> xmin;
-        mutable std::vector<index_t> xmax;
-        mutable std::vector<index_t> ymin;
-        mutable std::vector<index_t> ymax;
-        mutable std::vector<bool> empty;
+        /**
+         * @brief Updates local caches after a bulk transfer of all proper parts from source to target.
+         */
+        void onMoveProperParts(index_t targetId, index_t sourceId, const tree_type &tree) const override {
+            ensureLocalSummary(targetId, tree);
+            ensureLocalSummary(sourceId, tree);
+            mergeLocalBoxes(local_[(size_t) targetId], local_[(size_t) sourceId]);
+            resetLocalSummary(sourceId);
+        }
+
+        /**
+         * @brief Updates local caches after moving a single proper part between two nodes.
+         * @details The target cache is updated eagerly. The source cache stays exact as long as
+         * the removed pixel does not exhaust one extremum; otherwise it is marked dirty and
+         * rebuilt lazily on the next access.
+         */
+        void onMoveProperPart(index_t targetId, index_t sourceId, index_t pixelId, const tree_type &tree) const override {
+            ensureLocalSummary(targetId, tree);
+            if (sourceId != invalid_index) {
+                ensureLocalSummary(sourceId, tree);
+            }
+            expandLocalBoxWithPixel(local_[(size_t) targetId], pixelId);
+            local_[(size_t) targetId].properPartCount += 1;
+            local_[(size_t) targetId].dirty = 0;
+            if (sourceId != invalid_index) {
+                auto &source = local_[(size_t) sourceId];
+                if (source.properPartCount <= 1) {
+                    resetLocalSummary(sourceId);
+                    return;
+                }
+
+                const auto point = pixelToPoint(pixelId);
+                const auto y = (index_t) point.first;
+                const auto x = (index_t) point.second;
+                --source.properPartCount;
+
+                bool exhaustsXmin = false;
+                bool exhaustsXmax = false;
+                bool exhaustsYmin = false;
+                bool exhaustsYmax = false;
+
+                if (!source.dirty) {
+                    if (x == source.xmin) {
+                        if (source.xminCount <= 1) {
+                            exhaustsXmin = true;
+                        } else {
+                            --source.xminCount;
+                        }
+                    }
+
+                    if (x == source.xmax) {
+                        if (source.xmaxCount <= 1) {
+                            exhaustsXmax = true;
+                        } else {
+                            --source.xmaxCount;
+                        }
+                    }
+
+                    if (y == source.ymin) {
+                        if (source.yminCount <= 1) {
+                            exhaustsYmin = true;
+                        } else {
+                            --source.yminCount;
+                        }
+                    }
+
+                    if (y == source.ymax) {
+                        if (source.ymaxCount <= 1) {
+                            exhaustsYmax = true;
+                        } else {
+                            --source.ymaxCount;
+                        }
+                    }
+                }
+
+                source.dirty = source.dirty || exhaustsXmin || exhaustsXmax || exhaustsYmin || exhaustsYmax;
+            }
+        }
+
+        /**
+         * @brief Clears cached summaries of a removed node so stale boxes cannot be reused.
+         */
+        void onNodeRemoved(index_t nodeId, const tree_type &) const override {
+            resetLocalSummary(nodeId);
+            resetSubtreeSummary(nodeId);
+        }
+
+    
     };
 
 } // namespace hg::detail::hierarchy

--- a/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
+++ b/include/higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp
@@ -83,7 +83,7 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Incremental area computer for the internal dynamic component tree.
-     * @details Computes the canonical increasing area attribute by counting the
+     * @details Computes the increasing area attribute by counting the
      * proper parts directly owned by each node and accumulating child areas. The
      * single-node refresh contract is therefore straightforward: once child areas are
      * current, recomputing a parent requires only its direct proper-part count and the
@@ -118,12 +118,12 @@ namespace hg::detail::hierarchy {
 
     /**
      * @brief Incremental bounding-box attribute computer for dynamic component trees.
-     * @details The constructor receives a pixel-to-point functor so the tree backend
-     * stays independent from any specific image embedding. The resulting scalar can
+     * @details The constructor receives a mapping from proper-part ids to points so the tree
+     * backend stays independent of any specific graph embedding. The resulting scalar can
      * be the box width, height, or diagonal length.
      *
      * The computer keeps per-node mutable auxiliary buffers: `local_` stores the box of
-     * direct proper parts together with extremum multiplicities, while `subtree_` stores
+     * direct proper parts together with counts for each box extremum, while `subtree_` stores
      * the accumulated box after child merges. Consequently, a single-node refresh with
      * `computeAttributeOnNode(...)` is valid only when applied bottom-up on the affected
      * path, after all edited children have themselves been refreshed.
@@ -169,7 +169,7 @@ namespace hg::detail::hierarchy {
         mutable std::vector<DynamicComponentTreeBoundingBoxState> subtree_;
 
         /**
-         * @brief Restores an empty local box and clears all extremum multiplicities.
+         * @brief Restores an empty local box and clears all bounding-box extremum counts.
          */
         void resetLocalBox(DynamicComponentTreeBoundingBoxLocalSummary &local) const {
             local.xmin = 0;
@@ -293,7 +293,7 @@ namespace hg::detail::hierarchy {
         }
 
         /**
-         * @brief Unions a child subtree box into an accumulated parent subtree box.
+         * @brief Merges a child subtree bounding box into the accumulated parent bounding box.
          */
         void mergeSubtreeStates(DynamicComponentTreeBoundingBoxState &target, const DynamicComponentTreeBoundingBoxState &source) const {
             if (source.empty) {
@@ -426,8 +426,8 @@ namespace hg::detail::hierarchy {
         /**
          * @brief Updates local caches after moving a single proper part between two nodes.
          * @details The target cache is updated eagerly. The source cache stays exact as long as
-         * the removed pixel does not exhaust one extremum; otherwise it is marked dirty and
-         * rebuilt lazily on the next access.
+         * the removed proper part is not the last one attaining any bounding-box extremum;
+         * otherwise it is marked dirty and rebuilt lazily on the next access.
          */
         void onMoveProperPart(index_t targetId, index_t sourceId, index_t pixelId, const tree_type &tree) const override {
             ensureLocalSummary(targetId, tree);

--- a/include/higra/hierarchy/component_tree_casf.hpp
+++ b/include/higra/hierarchy/component_tree_casf.hpp
@@ -1,0 +1,380 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "higra/algo/tree.hpp"
+#include "higra/attribute/tree_attribute.hpp"
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp"
+
+namespace hg {
+
+    namespace testing {
+        struct ComponentTreeCasfTestAccess;
+    }
+
+    /**
+     * @brief Increasing attributes currently supported by the component-tree CASF.
+     */
+    enum class ComponentTreeCasfAttribute {
+        area,
+        bounding_box_width,
+        bounding_box_height,
+        bounding_box_diagonal
+    };
+
+    /**
+     * @brief Connected alternating sequential filter driven by paired dynamic min-tree / max-tree updates.
+     *
+     * This class implements a connected alternating sequential filter
+     * (CASF) on a fixed image-domain graph. Instead of rebuilding both trees
+     * after each threshold step, it maintains a mutable min-tree / max-tree pair
+     * and updates one tree incrementally when rooted subtrees are pruned from the
+     * dual one.
+     *
+     * Supported workflow:
+     *  - build the initial dynamic min-tree and max-tree from an input image;
+     *  - choose one increasing attribute used to select pruning candidates
+     *    (`area`, `bounding_box_width`, `bounding_box_height`, or
+     *    `bounding_box_diagonal`);
+     *  - run `filter(thresholds)` on one or several threshold sequences applied
+     *    successively to the current state;
+     *  - export the current dynamic state back to Higra's static
+     *    `tree + altitudes` representation with `exportMaxTree()` and
+     *    `exportMinTree()`.
+     *
+     * Internal state owned by this class:
+     *  - the mutable dynamic min-tree and max-tree;
+     *  - the node-altitude buffers associated with both trees;
+     *  - the incremental attribute computer and its output buffers;
+     *  - the dual-tree adjustment helper used to propagate subtree pruning from
+     *    one tree to the other;
+     *  - temporary buffers reused to select maximal pruning candidates.
+     *
+     * Update semantics:
+     *  - calling `filter(...)` with a non-empty threshold sequence mutates the
+     *    internal dynamic trees;
+     *  - later `filter(...)` calls continue from the current filtered state;
+     *  - an empty threshold sequence leaves the current state unchanged.
+     *
+     * Graph requirements:
+     *  - the graph must remain valid for the whole lifetime of the object;
+     *  - `area` is supported on any graph type accepted by the component-tree
+     *    builders;
+     *  - bounding-box attributes additionally require a graph exposing a 2D
+     *    `embedding()`.
+     */
+    template<typename altitude_t, typename graph_t>
+    class ComponentTreeCasf {
+    public:
+        using tree_t = detail::hierarchy::DynamicComponentTree;
+        using attribute_computer_t = detail::hierarchy::DynamicComponentTreeAttributeComputer<double>;
+
+        /**
+         * @brief Static export of one current component-tree state.
+         * @details `tree` and `altitudes` follow Higra's usual static component-tree conventions.
+         */
+        struct ExportedTree {
+            tree tree;
+            array_1d<altitude_t> altitudes;
+        };
+
+    private:
+        friend struct testing::ComponentTreeCasfTestAccess;
+
+        /**
+         * @brief Detects whether the graph type exposes an `embedding()` method.
+         */
+        template<typename g_t, typename = void>
+        struct has_embedding_impl : std::false_type {
+        };
+
+        /**
+         * @brief Specialization enabled when the graph type exposes an `embedding()` method.
+         */
+        template<typename g_t>
+        struct has_embedding_impl<g_t, std::void_t<decltype(std::declval<const g_t &>().embedding())>> : std::true_type {
+        };
+
+        const graph_t *graph_ = nullptr;
+        tree_t mintree_;
+        tree_t maxtree_;
+        std::unique_ptr<detail::hierarchy::DualMinMaxTreeIncrementalFilter<altitude_t, graph_t>> adjust_;
+        std::unique_ptr<attribute_computer_t> attributeComputer_;
+        std::vector<double> attributeBufferMin_;
+        std::vector<double> attributeBufferMax_;
+        array_1d<altitude_t> altitudeBufferMin_;
+        array_1d<altitude_t> altitudeBufferMax_;
+        std::vector<index_t> pruneCandidateQueue_;
+        std::vector<index_t> selectedPruneCandidates_;
+        ComponentTreeCasfAttribute attribute_;
+        static constexpr bool graph_has_embedding = has_embedding_impl<graph_t>::value;
+
+        /**
+         * @brief Returns `true` iff the selected CASF attribute is bounding-box-based.
+         */
+        static bool usesBoundingBoxAttribute(ComponentTreeCasfAttribute attribute) {
+            return attribute == ComponentTreeCasfAttribute::bounding_box_width ||
+                   attribute == ComponentTreeCasfAttribute::bounding_box_height ||
+                   attribute == ComponentTreeCasfAttribute::bounding_box_diagonal;
+        }
+
+        /**
+         * @brief Creates the incremental attribute computer matching the selected CASF attribute.
+         * @details Area uses a scalar area computer. Bounding-box attributes require a graph with a 2D embedding.
+         */
+        static std::unique_ptr<attribute_computer_t> makeAttributeComputer(const graph_t &graph, ComponentTreeCasfAttribute attribute) {
+            if (!usesBoundingBoxAttribute(attribute)) {
+                return std::make_unique<detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<>>();
+            }
+
+            if constexpr (graph_has_embedding) {
+                using embedding_t = std::remove_cv_t<std::remove_reference_t<decltype(std::declval<const graph_t &>().embedding())>>;
+                static_assert(embedding_t::_dim == 2, "Bounding-box CASF attributes require a graph with a 2D embedding.");
+
+                auto pixelToPoint = [&embedding = graph.embedding()](index_t pixelId) {
+                    const auto point = embedding.lin2grid(pixelId);
+                    return std::pair<index_t, index_t>{point[0], point[1]};
+                };
+
+                using pixel_to_point_t = decltype(pixelToPoint);
+                auto measure = detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::diagonal_length;
+                switch (attribute) {
+                    case ComponentTreeCasfAttribute::bounding_box_width:
+                        measure = detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::width;
+                        break;
+                    case ComponentTreeCasfAttribute::bounding_box_height:
+                        measure = detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::height;
+                        break;
+                    case ComponentTreeCasfAttribute::bounding_box_diagonal:
+                        measure = detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::diagonal_length;
+                        break;
+                    case ComponentTreeCasfAttribute::area:
+                        hg_assert(false, "Bounding-box attribute computer requested from area attribute.");
+                        break;
+                }
+                return std::make_unique<detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<pixel_to_point_t>>(pixelToPoint, measure);
+            } else {
+                hg_assert(false, "Bounding-box CASF attributes require a graph exposing a 2D embedding.");
+                return nullptr;
+            }
+        }
+
+        /**
+         * @brief Reconstructs the current filtered image from the dynamic tree and its node altitudes.
+         * @details Each pixel is assigned the altitude of its current smallest surviving component.
+         */
+        template<typename altitude_buffer_t>
+        static array_1d<altitude_t> reconstructImage(const tree_t &tree, const altitude_buffer_t &altitude) {
+            const index_t numPixels = tree.getNumTotalProperParts();
+            auto image = array_1d<altitude_t>::from_shape({(size_t) numPixels});
+            for (index_t p = 0; p < numPixels; ++p) {
+                const auto nodeId = tree.getSmallestComponent(p);
+                hg_assert(nodeId != invalid_index, "Each pixel must map to a valid surviving component.");
+                image(p) = altitude[(size_t) nodeId];
+            }
+            return image;
+        }
+
+        /**
+         * @brief Selects maximal non-root pruning candidates whose increasing attribute is below or equal to a threshold.
+         * @details Traverses the rooted hierarchy in breadth-first order, following the same selection semantics used
+         * in MorphoTreeAdjust: descend while `attribute(node) > threshold`, otherwise select the current node and stop
+         * descending below it. The root is never returned because `DynamicComponentTree::pruneNode` requires a non-root
+         * node. Internal queue/output buffers are reused across calls and sized from the largest dynamic tree.
+         */
+        template<typename attribute_buffer_t, typename value_t> std::vector<index_t> selectPruneCandidates(const tree_t &tree, const attribute_buffer_t &attribute, value_t threshold) {
+            pruneCandidateQueue_.clear();
+            selectedPruneCandidates_.clear();
+            const auto root = tree.getRoot();
+            if (root == invalid_index || !tree.isAlive(root)) {
+                return selectedPruneCandidates_;
+            }
+
+            pruneCandidateQueue_.push_back(root);
+            std::size_t head = 0;
+
+            while (head < pruneCandidateQueue_.size()) {
+                const auto nodeId = pruneCandidateQueue_[head++];
+
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+
+                const auto nodeAttribute = attribute[(size_t) nodeId];
+                if (!tree.isRoot(nodeId) && nodeAttribute <= threshold) {
+                    selectedPruneCandidates_.push_back(nodeId);
+                    continue;
+                }
+
+                for (auto childId: tree.getChildren(nodeId)) {
+                    if (tree.isAlive(childId)) {
+                        pruneCandidateQueue_.push_back(childId);
+                    }
+                }
+            }
+
+            return selectedPruneCandidates_;
+        }
+
+        /**
+         * @brief Applies one threshold step of the CASF on the current dynamic state.
+         * @details The step first applies the extensive half-step (max-tree pruning, min-tree update), then the
+         * anti-extensive half-step (min-tree pruning, max-tree update).
+         */
+        void applyFilterStep(double threshold) {
+            const auto candidates1 = selectPruneCandidates(maxtree_, attributeBufferMax_, threshold);
+            adjust_->pruneMaxTreeAndUpdateMinTree(candidates1);
+
+            const auto candidates2 = selectPruneCandidates(mintree_, attributeBufferMin_, threshold);
+            adjust_->pruneMinTreeAndUpdateMaxTree(candidates2);
+        }
+
+        /**
+         * @brief Exports one dynamic tree state to Higra's static `tree + altitudes` representation.
+         * @details Alive dynamic nodes are reindexed after the leaves while preserving the monotone topological
+         * ordering expected by Higra's static `tree` structure.
+         */
+        template<typename altitude_buffer_t>
+        ExportedTree exportTreeState(const tree_t &tree, const altitude_buffer_t &altitude) const {
+            hg_assert(altitude.size() >= (size_t) tree.getGlobalIdSpaceSize(), "Altitude buffer must cover the full dynamic-tree global id space.");
+
+            const index_t numLeaves = tree.getNumTotalProperParts();
+            const index_t numAliveNodes = tree.getNumNodes();
+            const index_t numVertices = numLeaves + numAliveNodes;
+
+            auto parents = array_1d<index_t>::from_shape({(size_t) numVertices});
+            auto exportedAltitude = array_1d<altitude_t>::from_shape({(size_t) numVertices});
+            std::vector<index_t> oldToNew((size_t) tree.getGlobalIdSpaceSize(), invalid_index);
+            std::vector<index_t> exportedNodes;
+            exportedNodes.reserve((size_t) numAliveNodes);
+
+            for (index_t p = 0; p < numLeaves; ++p) {
+                oldToNew[(size_t) p] = p;
+                const auto ownerId = tree.getSmallestComponent(p);
+                hg_assert(ownerId != invalid_index, "Each proper part must map to a valid alive component.");
+                exportedAltitude(p) = altitude[(size_t) ownerId];
+            }
+
+            bool sortAscendingAltitude = true;
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+                exportedNodes.push_back(nodeId);
+                if (!tree.isRoot(nodeId)) {
+                    const auto parentId = tree.getNodeParent(nodeId);
+                    hg_assert(parentId != invalid_index, "Alive exported node must have a valid parent.");
+                    if (altitude[(size_t) nodeId] > altitude[(size_t) parentId]) {
+                        sortAscendingAltitude = false;
+                    }
+                }
+            }
+
+            hg_assert((index_t) exportedNodes.size() == numAliveNodes, "Export expects the rooted dynamic tree to contain all alive nodes.");
+
+            std::stable_sort(exportedNodes.begin(), exportedNodes.end(),
+                             [&](index_t lhs, index_t rhs) {
+                                 const auto altL = altitude[(size_t) lhs];
+                                 const auto altR = altitude[(size_t) rhs];
+                                 if (altL != altR) {
+                                     return sortAscendingAltitude ? altL < altR : altL > altR;
+                                 }
+                                 return lhs < rhs;
+                             });
+
+            for (index_t i = 0; i < numAliveNodes; ++i) {
+                const auto oldNodeId = exportedNodes[(size_t) i];
+                const auto newNodeId = numLeaves + i;
+                oldToNew[(size_t) oldNodeId] = newNodeId;
+                exportedAltitude(newNodeId) = altitude[(size_t) oldNodeId];
+            }
+
+            for (index_t p = 0; p < numLeaves; ++p) {
+                const auto ownerId = tree.getSmallestComponent(p);
+                hg_assert(ownerId != invalid_index, "Each proper part must map to a valid alive component.");
+                parents(p) = oldToNew[(size_t) ownerId];
+            }
+
+            for (auto oldNodeId: exportedNodes) {
+                const auto newNodeId = oldToNew[(size_t) oldNodeId];
+                const auto oldParentId = tree.getNodeParent(oldNodeId);
+                parents(newNodeId) = oldParentId == oldNodeId ? newNodeId : oldToNew[(size_t) oldParentId];
+            }
+
+            auto exportedTree = hg::tree(parents);
+            return ExportedTree{std::move(exportedTree), std::move(exportedAltitude)};
+        }
+
+    public:
+        /**
+         * @brief Initializes the CASF state from the input image and the chosen increasing attribute.
+         * @param graph Adjacency graph of the image domain.
+         * @param image Input image values on the graph vertices.
+         * @param attribute Increasing attribute used to select pruning candidates.
+         */
+        ComponentTreeCasf(const graph_t &graph, const array_1d<altitude_t> &image, ComponentTreeCasfAttribute attribute = ComponentTreeCasfAttribute::area)
+                : graph_(&graph), attributeComputer_(nullptr), attribute_(attribute) {
+            const auto minStatic = component_tree_min_tree(*graph_, image);
+            const auto maxStatic = component_tree_max_tree(*graph_, image);
+            altitudeBufferMin_ = std::move(minStatic.altitudes);
+            altitudeBufferMax_ = std::move(maxStatic.altitudes);
+            mintree_.reset(minStatic.tree);
+            maxtree_.reset(maxStatic.tree);
+            attributeComputer_ = makeAttributeComputer(*graph_, attribute_);
+            adjust_ = std::make_unique<detail::hierarchy::DualMinMaxTreeIncrementalFilter<altitude_t, graph_t>>(&mintree_, &maxtree_, *graph_);
+            adjust_->setAttributeComputer(*attributeComputer_, attributeBufferMin_, attributeBufferMax_);
+            adjust_->setAltitudeBuffers(altitudeBufferMin_, altitudeBufferMax_);
+            attributeComputer_->computeAttribute(mintree_, attributeBufferMin_);
+            attributeComputer_->computeAttribute(maxtree_, attributeBufferMax_);
+            const auto maxNodes = (std::size_t) std::max(mintree_.getNumNodes(), maxtree_.getNumNodes());
+            pruneCandidateQueue_.reserve(maxNodes);
+            selectedPruneCandidates_.reserve(maxNodes);
+        }
+
+        /**
+         * @brief Runs the CASF on the threshold sequence and returns the filtered image.
+         * @details Thresholds are applied to the current internal state. This object is therefore stateful:
+         * successive non-empty calls continue filtering the result of the previous ones.
+         */
+        array_1d<altitude_t> filter(const std::vector<double> &thresholds) {
+            for (auto threshold: thresholds) {
+                applyFilterStep(threshold);
+            }
+            return reconstructImage(mintree_, altitudeBufferMin_);
+        }
+
+        /**
+         * @brief Exports the current max-tree state to Higra's static representation.
+         */
+        ExportedTree exportMaxTree() const {
+            return exportTreeState(maxtree_, altitudeBufferMax_);
+        }
+
+        /**
+         * @brief Exports the current min-tree state to Higra's static representation.
+         */
+        ExportedTree exportMinTree() const {
+            return exportTreeState(mintree_, altitudeBufferMin_);
+        }
+    };
+
+    namespace testing {
+
+        struct ComponentTreeCasfTestAccess {
+            template<typename altitude_t, typename graph_t, typename attribute_buffer_t, typename value_t> static std::vector<index_t>
+            selectPruneCandidates(ComponentTreeCasf<altitude_t, graph_t> &casf, const typename ComponentTreeCasf<altitude_t, graph_t>::tree_t &tree, const attribute_buffer_t &attribute, value_t threshold) {
+                return casf.selectPruneCandidates(tree, attribute, threshold);
+            }
+        };
+
+    } // namespace testing
+
+} // namespace hg

--- a/include/higra/hierarchy/component_tree_casf.hpp
+++ b/include/higra/hierarchy/component_tree_casf.hpp
@@ -53,7 +53,7 @@ namespace hg {
      * Internal state owned by this class:
      *  - the mutable dynamic min-tree and max-tree;
      *  - the node-altitude buffers associated with both trees;
-     *  - the incremental attribute computer and its output buffers;
+     *  - one incremental attribute computer per dynamic tree and their output buffers;
      *  - the dual-tree adjustment helper used to propagate subtree pruning from
      *    one tree to the other;
      *  - temporary buffers reused to select maximal pruning candidates.
@@ -107,7 +107,8 @@ namespace hg {
         tree_t mintree_;
         tree_t maxtree_;
         std::unique_ptr<detail::hierarchy::DualMinMaxTreeIncrementalFilter<altitude_t, graph_t>> adjust_;
-        std::unique_ptr<attribute_computer_t> attributeComputer_;
+        std::unique_ptr<attribute_computer_t> attributeComputerMin_;
+        std::unique_ptr<attribute_computer_t> attributeComputerMax_;
         std::vector<double> attributeBufferMin_;
         std::vector<double> attributeBufferMax_;
         array_1d<altitude_t> altitudeBufferMin_;
@@ -321,19 +322,20 @@ namespace hg {
          * @param attribute Increasing attribute used to select pruning candidates.
          */
         ComponentTreeCasf(const graph_t &graph, const array_1d<altitude_t> &image, ComponentTreeCasfAttribute attribute = ComponentTreeCasfAttribute::area)
-                : graph_(&graph), attributeComputer_(nullptr), attribute_(attribute) {
+                : graph_(&graph), attributeComputerMin_(nullptr), attributeComputerMax_(nullptr), attribute_(attribute) {
             const auto minStatic = component_tree_min_tree(*graph_, image);
             const auto maxStatic = component_tree_max_tree(*graph_, image);
             altitudeBufferMin_ = std::move(minStatic.altitudes);
             altitudeBufferMax_ = std::move(maxStatic.altitudes);
             mintree_.reset(minStatic.tree);
             maxtree_.reset(maxStatic.tree);
-            attributeComputer_ = makeAttributeComputer(*graph_, attribute_);
+            attributeComputerMin_ = makeAttributeComputer(*graph_, attribute_);
+            attributeComputerMax_ = makeAttributeComputer(*graph_, attribute_);
             adjust_ = std::make_unique<detail::hierarchy::DualMinMaxTreeIncrementalFilter<altitude_t, graph_t>>(&mintree_, &maxtree_, *graph_);
-            adjust_->setAttributeComputer(*attributeComputer_, attributeBufferMin_, attributeBufferMax_);
+            adjust_->setAttributeComputer(*attributeComputerMin_, *attributeComputerMax_, attributeBufferMin_, attributeBufferMax_);
             adjust_->setAltitudeBuffers(altitudeBufferMin_, altitudeBufferMax_);
-            attributeComputer_->computeAttribute(mintree_, attributeBufferMin_);
-            attributeComputer_->computeAttribute(maxtree_, attributeBufferMax_);
+            attributeComputerMin_->computeAttribute(mintree_, attributeBufferMin_);
+            attributeComputerMax_->computeAttribute(maxtree_, attributeBufferMax_);
             const auto maxNodes = (std::size_t) std::max(mintree_.getNumNodes(), maxtree_.getNumNodes());
             pruneCandidateQueue_.reserve(maxNodes);
             selectedPruneCandidates_.reserve(maxNodes);

--- a/include/higra/hierarchy/component_tree_casf.hpp
+++ b/include/higra/hierarchy/component_tree_casf.hpp
@@ -21,7 +21,7 @@ namespace hg {
     }
 
     /**
-     * @brief Increasing attributes currently supported by the component-tree CASF.
+     * @brief Increasing attributes currently supported by the component tree CASF.
      */
     enum class ComponentTreeCasfAttribute {
         area,
@@ -31,24 +31,23 @@ namespace hg {
     };
 
     /**
-     * @brief Connected alternating sequential filter driven by paired dynamic min-tree / max-tree updates.
+     * @brief Connected alternating sequential filter driven by paired dynamic min-tree and max-tree updates.
      *
      * This class implements a connected alternating sequential filter
-     * (CASF) on a fixed image-domain graph. Instead of rebuilding both trees
-     * after each threshold step, it maintains a mutable min-tree / max-tree pair
+     * (CASF) on a fixed input graph. Instead of rebuilding both trees after
+     * each threshold step, it maintains a mutable min-tree and max-tree pair
      * and updates one tree incrementally when rooted subtrees are pruned from the
-     * dual one.
+     * corresponding dual tree.
      *
      * Supported workflow:
-     *  - build the initial dynamic min-tree and max-tree from an input image;
+     *  - build the initial dynamic min-tree and max-tree from input vertex weights;
      *  - choose one increasing attribute used to select pruning candidates
      *    (`area`, `bounding_box_width`, `bounding_box_height`, or
      *    `bounding_box_diagonal`);
      *  - run `filter(thresholds)` on one or several threshold sequences applied
      *    successively to the current state;
-     *  - export the current dynamic state back to Higra's static
-     *    `tree + altitudes` representation with `exportMaxTree()` and
-     *    `exportMinTree()`.
+     *  - export the current dynamic state back to Higra's static tree and
+     *    altitude arrays with `exportMaxTree()` and `exportMinTree()`.
      *
      * Internal state owned by this class:
      *  - the mutable dynamic min-tree and max-tree;
@@ -66,8 +65,8 @@ namespace hg {
      *
      * Graph requirements:
      *  - the graph must remain valid for the whole lifetime of the object;
-     *  - `area` is supported on any graph type accepted by the component-tree
-     *    builders;
+     *  - `area` is supported on any graph type accepted by the component tree
+     *    construction functions;
      *  - bounding-box attributes additionally require a graph exposing a 2D
      *    `embedding()`.
      */
@@ -78,8 +77,8 @@ namespace hg {
         using attribute_computer_t = detail::hierarchy::DynamicComponentTreeAttributeComputer<double>;
 
         /**
-         * @brief Static export of one current component-tree state.
-         * @details `tree` and `altitudes` follow Higra's usual static component-tree conventions.
+         * @brief Static export of one current component tree state.
+         * @details `tree` and `altitudes` follow Higra's usual static component tree conventions.
          */
         struct ExportedTree {
             tree tree;
@@ -119,7 +118,7 @@ namespace hg {
         static constexpr bool graph_has_embedding = has_embedding_impl<graph_t>::value;
 
         /**
-         * @brief Returns `true` iff the selected CASF attribute is bounding-box-based.
+         * @brief Returns `true` if and only if the selected CASF attribute is bounding-box-based.
          */
         static bool usesBoundingBoxAttribute(ComponentTreeCasfAttribute attribute) {
             return attribute == ComponentTreeCasfAttribute::bounding_box_width ||
@@ -169,8 +168,8 @@ namespace hg {
         }
 
         /**
-         * @brief Reconstructs the current filtered image from the dynamic tree and its node altitudes.
-         * @details Each pixel is assigned the altitude of its current smallest surviving component.
+         * @brief Reconstructs the current filtered vertex weights from the dynamic tree and its node altitudes.
+         * @details Each input vertex is assigned the altitude of its current smallest surviving component.
          */
         template<typename altitude_buffer_t>
         static array_1d<altitude_t> reconstructImage(const tree_t &tree, const altitude_buffer_t &altitude) {
@@ -227,8 +226,8 @@ namespace hg {
 
         /**
          * @brief Applies one threshold step of the CASF on the current dynamic state.
-         * @details The step first applies the extensive half-step (max-tree pruning, min-tree update), then the
-         * anti-extensive half-step (min-tree pruning, max-tree update).
+         * @details The step first applies the anti-extensive attribute opening (max-tree pruning, min-tree update),
+         * then the extensive attribute closing (min-tree pruning, max-tree update).
          */
         void applyFilterStep(double threshold) {
             const auto candidates1 = selectPruneCandidates(maxtree_, attributeBufferMax_, threshold);
@@ -239,7 +238,7 @@ namespace hg {
         }
 
         /**
-         * @brief Exports one dynamic tree state to Higra's static `tree + altitudes` representation.
+         * @brief Exports one dynamic tree state to Higra's static tree and altitude arrays.
          * @details Alive dynamic nodes are reindexed after the leaves while preserving the monotone topological
          * ordering expected by Higra's static `tree` structure.
          */
@@ -316,9 +315,9 @@ namespace hg {
 
     public:
         /**
-         * @brief Initializes the CASF state from the input image and the chosen increasing attribute.
-         * @param graph Adjacency graph of the image domain.
-         * @param image Input image values on the graph vertices.
+         * @brief Initializes the CASF state from input vertex weights and the chosen increasing attribute.
+         * @param graph Input adjacency graph.
+         * @param image Input vertex weights.
          * @param attribute Increasing attribute used to select pruning candidates.
          */
         ComponentTreeCasf(const graph_t &graph, const array_1d<altitude_t> &image, ComponentTreeCasfAttribute attribute = ComponentTreeCasfAttribute::area)
@@ -342,7 +341,7 @@ namespace hg {
         }
 
         /**
-         * @brief Runs the CASF on the threshold sequence and returns the filtered image.
+         * @brief Runs the CASF on the threshold sequence and returns the filtered vertex weights.
          * @details Thresholds are applied to the current internal state. This object is therefore stateful:
          * successive non-empty calls continue filtering the result of the previous ones.
          */

--- a/test/cpp/hierarchy/CMakeLists.txt
+++ b/test/cpp/hierarchy/CMakeLists.txt
@@ -13,6 +13,5 @@ set(TEST_CPP_COMPONENTS ${TEST_CPP_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_component_tree.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_hierarchy_core.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_watershed_hierarchy.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree.cpp
         PARENT_SCOPE)
-
-

--- a/test/cpp/hierarchy/CMakeLists.txt
+++ b/test/cpp/hierarchy/CMakeLists.txt
@@ -14,4 +14,5 @@ set(TEST_CPP_COMPONENTS ${TEST_CPP_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_hierarchy_core.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_watershed_hierarchy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree_attribute_computers.cpp
         PARENT_SCOPE)

--- a/test/cpp/hierarchy/CMakeLists.txt
+++ b/test/cpp/hierarchy/CMakeLists.txt
@@ -15,4 +15,5 @@ set(TEST_CPP_COMPONENTS ${TEST_CPP_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_watershed_hierarchy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree_attribute_computers.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_component_tree_adjustment.cpp
         PARENT_SCOPE)

--- a/test/cpp/hierarchy/CMakeLists.txt
+++ b/test/cpp/hierarchy/CMakeLists.txt
@@ -15,5 +15,5 @@ set(TEST_CPP_COMPONENTS ${TEST_CPP_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_watershed_hierarchy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree_attribute_computers.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/test_component_tree_adjustment.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_dual_min_max_tree_incremental_filter.cpp
         PARENT_SCOPE)

--- a/test/cpp/hierarchy/CMakeLists.txt
+++ b/test/cpp/hierarchy/CMakeLists.txt
@@ -11,6 +11,7 @@
 set(TEST_CPP_COMPONENTS ${TEST_CPP_COMPONENTS}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_binary_partition_tree.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_component_tree.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_component_tree_casf.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_hierarchy_core.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_watershed_hierarchy.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic_component_tree.cpp

--- a/test/cpp/hierarchy/test_component_tree_adjustment.cpp
+++ b/test/cpp/hierarchy/test_component_tree_adjustment.cpp
@@ -1,0 +1,534 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "../test_utils.hpp"
+#include "higra/detail/hierarchy/component_tree_adjustment.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp"
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/image/graph_image.hpp"
+#include <map>
+
+using namespace hg;
+
+namespace component_tree_adjustment {
+
+using detail::hierarchy::testing::ComponentTreeAdjustmentTestAccess;
+
+namespace {
+
+        using tree_t = detail::hierarchy::DynamicComponentTree;
+
+        array_1d<uint8_t> make_demo_image() {
+            constexpr index_t numPixels = 144;
+            uint8_t raw[numPixels] = {
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+                    2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+                    6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+                    7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1};
+
+            auto image = array_1d<uint8_t>::from_shape({numPixels});
+            for (index_t i = 0; i < numPixels; ++i) {
+                image(i) = raw[i];
+            }
+            return image;
+        }
+
+        array_1d<float> make_demo_image_non_integral_float() {
+            const auto image = make_demo_image();
+            auto out = array_1d<float>::from_shape({image.size()});
+            for (index_t i = 0; i < (index_t) image.size(); ++i) {
+                out(i) = (float) image(i) + 0.25f;
+            }
+            return out;
+        }
+
+        template<typename graph_t>
+        std::pair<tree_t, std::vector<uint8_t>> make_component_tree_with_altitude(const graph_t &graph,
+                                                                                  const array_1d<uint8_t> &image,
+                                                                                  bool isMaxTree) {
+            const auto staticTree = isMaxTree ? component_tree_max_tree(graph, image) : component_tree_min_tree(graph, image);
+            tree_t tree;
+            tree.reset(staticTree.tree);
+            return {std::move(tree), std::vector<uint8_t>(staticTree.altitudes.begin(), staticTree.altitudes.end())};
+        }
+
+        template<typename altitude_t>
+        array_1d<altitude_t> reconstruct_image_from_dynamic_tree(const detail::hierarchy::DynamicComponentTree &tree,
+                                                                 const std::vector<altitude_t> &altitude) {
+            // Reconstructs the current image by assigning each pixel the altitude of its current smallest component.
+            auto image = array_1d<altitude_t>::from_shape({(size_t) tree.getNumTotalProperParts()});
+            for (index_t p = 0; p < tree.getNumTotalProperParts(); ++p) {
+                const auto nodeId = tree.getSmallestComponent(p);
+                REQUIRE(nodeId != invalid_index);
+                image(p) = altitude[(size_t) nodeId];
+            }
+            return image;
+        }
+
+        template<typename altitude_t>
+        void require_tree_matches_rebuilt_image_baseline(const detail::hierarchy::DynamicComponentTree &updatedTree,
+                                                         const std::vector<altitude_t> &updatedAltitude,
+                                                         const detail::hierarchy::DynamicComponentTree &prunedDualTree,
+                                                         const std::vector<altitude_t> &prunedDualAltitude) {
+            // The updated dual tree must represent exactly the same filtered image as the baseline obtained
+            // by pruning the source tree and reconstructing the filtered image from that modified hierarchy.
+            const auto updatedImage = reconstruct_image_from_dynamic_tree(updatedTree, updatedAltitude);
+            const auto expectedImage = reconstruct_image_from_dynamic_tree(prunedDualTree, prunedDualAltitude);
+            REQUIRE((updatedImage == expectedImage));
+        }
+
+        /*
+         * Reference maxtree and mintree for the 12x12 demo image.
+         *
+         * == Dynamic maxtree ==
+         * └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
+         *    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143],
+         *    ProperPartCount: 22
+         *    └──ID: 157, Parent: 158, Altitude: 2, NumChildren: 3,
+         *       ProperParts: [0, 1, 2, 3, 4, 5, 12, 19, 20, 21, 24, 31, 33, 36, 43, 45, 48, 55, 57, 60, 67, 68, 69, 84, 85, 86, 87, 88, 89, 101, 113, 125, 132, 133, 134, 135, 136, 137],
+         *       ProperPartCount: 38
+         *       ├──ID: 152, Parent: 157, Altitude: 5, NumChildren: 1, ProperParts: [32, 56], ProperPartCount: 2
+         *       │  └──ID: 150, Parent: 152, Altitude: 6, NumChildren: 0, ProperParts: [44], ProperPartCount: 1
+         *       ├──ID: 155, Parent: 157, Altitude: 3, NumChildren: 1, ProperParts: [109], ProperPartCount: 1
+         *       │  └──ID: 154, Parent: 155, Altitude: 4, NumChildren: 1, ProperParts: [111], ProperPartCount: 1
+         *       │     └──ID: 148, Parent: 154, Altitude: 6, NumChildren: 1,
+         *       │        ProperParts: [96, 97, 98, 99, 100, 110, 112, 122, 123, 124], ProperPartCount: 10
+         *       │        └──ID: 147, Parent: 148, Altitude: 7, NumChildren: 1, ProperParts: [108, 120], ProperPartCount: 2
+         *       │           └──ID: 144, Parent: 147, Altitude: 8, NumChildren: 0, ProperParts: [121], ProperPartCount: 1
+         *       └──ID: 156, Parent: 157, Altitude: 3, NumChildren: 2,
+         *          ProperParts: [16, 17, 18, 22, 28, 29, 30, 34, 40, 41, 42, 46, 52, 53, 54, 58, 64, 65, 66, 70, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 90, 91, 92, 93, 94],
+         *          ProperPartCount: 36
+         *          ├──ID: 151, Parent: 156, Altitude: 5, NumChildren: 1,
+         *          │  ProperParts: [13, 14, 15, 25, 27, 37, 39, 49, 51, 61, 62, 63], ProperPartCount: 12
+         *          │  └──ID: 149, Parent: 151, Altitude: 6, NumChildren: 0, ProperParts: [26, 38, 50], ProperPartCount: 3
+         *          └──ID: 153, Parent: 156, Altitude: 4, NumChildren: 2,
+         *             ProperParts: [102, 103, 104, 105, 106, 114, 116, 118, 126, 127, 128, 129, 130], ProperPartCount: 13
+         *             ├──ID: 145, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [117], ProperPartCount: 1
+         *             └──ID: 146, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [115], ProperPartCount: 1
+         *
+         * == Dynamic mintree ==
+         * └──ID: 153, Parent: 153, Altitude: 8, NumChildren: 1, ProperParts: [115, 117, 121], ProperPartCount: 3
+         *    └──ID: 152, Parent: 153, Altitude: 7, NumChildren: 1, ProperParts: [108, 120], ProperPartCount: 2
+         *       └──ID: 151, Parent: 152, Altitude: 6, NumChildren: 3,
+         *          ProperParts: [26, 38, 44, 50, 96, 97, 98, 99, 100, 110, 112, 122, 123, 124], ProperPartCount: 14
+         *          ├──ID: 146, Parent: 151, Altitude: 3, NumChildren: 0, ProperParts: [109], ProperPartCount: 1
+         *          ├──ID: 149, Parent: 151, Altitude: 4, NumChildren: 0, ProperParts: [111], ProperPartCount: 1
+         *          └──ID: 150, Parent: 151, Altitude: 5, NumChildren: 1,
+         *             ProperParts: [13, 14, 15, 25, 27, 32, 37, 39, 49, 51, 56, 61, 62, 63], ProperPartCount: 14
+         *             └──ID: 148, Parent: 150, Altitude: 4, NumChildren: 1,
+         *                ProperParts: [102, 103, 104, 105, 106, 114, 116, 118, 126, 127, 128, 129, 130], ProperPartCount: 13
+         *                └──ID: 147, Parent: 148, Altitude: 3, NumChildren: 1,
+         *                   ProperParts: [16, 17, 18, 22, 28, 29, 30, 34, 40, 41, 42, 46, 52, 53, 54, 58, 64, 65, 66, 70, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 90, 91, 92, 93, 94],
+         *                   ProperPartCount: 36
+         *                   └──ID: 145, Parent: 147, Altitude: 2, NumChildren: 1,
+         *                      ProperParts: [0, 1, 2, 3, 4, 5, 12, 19, 20, 21, 24, 31, 33, 36, 43, 45, 48, 55, 57, 60, 67, 68, 69, 84, 85, 86, 87, 88, 89, 101, 113, 125, 132, 133, 134, 135, 136, 137],
+         *                      ProperPartCount: 38
+         *                      └──ID: 144, Parent: 145, Altitude: 1, NumChildren: 0,
+         *                         ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143],
+         *                         ProperPartCount: 22
+         */
+
+        template<typename tree_t>
+        bool has_unreachable_alive_nodes(const tree_t &tree) {
+            // Detects alive internal nodes left outside the rooted final hierarchy.
+            std::vector<bool> reachable((size_t) tree.getGlobalIdSpaceSize(), false);
+            if (tree.getRoot() != invalid_index && tree.isAlive(tree.getRoot())) {
+                for (auto nodeId: tree.getNodeSubtree(tree.getRoot())) {
+                    reachable[(size_t) nodeId] = true;
+                }
+            }
+
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (tree.isAlive(nodeId) && !reachable[(size_t) nodeId]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        template<typename tree_t>
+        bool area_buffers_equal(const tree_t &tree,
+                                const std::vector<double> &incrementalArea,
+                                const std::vector<double> &fullArea) {
+            // Compares incremental and full recomputation only on alive internal nodes.
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+                if (incrementalArea[(size_t) nodeId] != fullArea[(size_t) nodeId]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        template<typename tree_t>
+        void require_tree_consistency(const tree_t &tree) {
+            // Rechecks the same structural invariants expected from a valid adjusted tree.
+            REQUIRE(tree.getRoot() != invalid_index);
+            REQUIRE(tree.isAlive(tree.getRoot()));
+            REQUIRE(!has_unreachable_alive_nodes(tree));
+
+            index_t totalProperParts = 0;
+            std::vector<bool> seenProperParts((size_t) tree.getNumTotalProperParts(), false);
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+
+                for (auto childId: tree.getChildren(nodeId)) {
+                    REQUIRE(tree.isAlive(childId));
+                    REQUIRE(tree.getNodeParent(childId) == nodeId);
+                    REQUIRE(tree.hasChild(nodeId, childId));
+                }
+
+                index_t countedProperParts = 0;
+                for (auto p: tree.getProperParts(nodeId)) {
+                    REQUIRE(tree.isProperPart(p));
+                    REQUIRE(tree.getSmallestComponent(p) == nodeId);
+                    REQUIRE(!seenProperParts[(size_t) p]);
+                    seenProperParts[(size_t) p] = true;
+                    countedProperParts++;
+                }
+                REQUIRE(countedProperParts == tree.getNumProperParts(nodeId));
+                totalProperParts += countedProperParts;
+            }
+
+            REQUIRE(totalProperParts == tree.getNumTotalProperParts());
+            REQUIRE(std::all_of(seenProperParts.begin(), seenProperParts.end(), [](bool v) { return v; }));
+        }
+
+        template<typename tree_t, typename altitude_t>
+        std::map<int, index_t> collect_alive_nodes_by_level(const tree_t &tree, const std::vector<altitude_t> &altitude) {
+            // Builds a compact structural signature that is stable across reruns of the same input.
+            std::map<int, index_t> hist;
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+                hist[(int) altitude[(size_t) nodeId]]++;
+            }
+            return hist;
+        }
+
+        template<typename tree_t>
+        void require_area_consistency(const tree_t &tree,
+                                      const std::vector<double> &incrementalArea,
+                                      detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> &areaComputer) {
+            // Recomputes area from scratch and checks it against the incremental buffer.
+            std::vector<double> fullArea;
+            areaComputer.computeAttribute(tree, fullArea);
+            REQUIRE(area_buffers_equal(tree, incrementalArea, fullArea));
+            REQUIRE(fullArea[(size_t) tree.getRoot()] == 144.0);
+            REQUIRE(incrementalArea[(size_t) tree.getRoot()] == 144.0);
+        }
+
+    } // namespace
+
+    TEST_CASE("component tree adjustment maxtree update matches the rebuild image baseline after mintree pruning", "[component_tree_adjustment]") {
+            // The updated maxtree must represent the same filtered image as a prune-then-rebuild baseline.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+
+            const index_t rootNodeC = mintree.getSmallestComponent(32);
+            REQUIRE(rootNodeC == 150);
+
+            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+            mintree.pruneNode(rootNodeC);
+
+            require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
+    }
+
+    TEST_CASE("component tree adjustment mintree update matches the rebuild image baseline after maxtree pruning", "[component_tree_adjustment]") {
+            // The symmetric update must represent the same filtered image as a prune-then-rebuild baseline.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+
+            const index_t rootNodeC = maxtree.getSmallestComponent(44);
+            REQUIRE(rootNodeC == 150);
+
+            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+            maxtree.pruneNode(rootNodeC);
+
+            require_tree_matches_rebuilt_image_baseline(mintree, minAltitude, maxtree, maxAltitude);
+    }
+
+    TEST_CASE("component tree adjustment matches the rebuild image baseline across sequential mintree prunes", "[component_tree_adjustment]") {
+            // Reusing the same adjustment helper across multiple rounds must stay equivalent to repeated prune-then-rebuild baselines.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+
+            for (const index_t pixelId: std::vector<index_t>{32, 82}) {
+                const index_t rootNodeC = mintree.getSmallestComponent(pixelId);
+                INFO("pixelId=" << pixelId << ", rootNodeC=" << rootNodeC);
+                REQUIRE(rootNodeC != invalid_index);
+                REQUIRE(mintree.isAlive(rootNodeC));
+                REQUIRE(!mintree.isRoot(rootNodeC));
+
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+                mintree.pruneNode(rootNodeC);
+
+                require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
+            }
+    }
+
+    TEST_CASE("component tree adjustment sparse backend matches the rebuild image baseline on non-integral float altitudes", "[component_tree_adjustment]") {
+            // The sparse backend must represent the same filtered image as a prune-then-rebuild baseline on non-integral levels.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image_non_integral_float();
+
+            const auto staticMaxTree = component_tree_max_tree(graph, image);
+            const auto staticMinTree = component_tree_min_tree(graph, image);
+            tree_t maxtree;
+            tree_t mintree;
+            maxtree.reset(staticMaxTree.tree);
+            mintree.reset(staticMinTree.tree);
+            std::vector<float> maxAltitude(staticMaxTree.altitudes.begin(), staticMaxTree.altitudes.end());
+            std::vector<float> minAltitude(staticMinTree.altitudes.begin(), staticMinTree.altitudes.end());
+
+            detail::hierarchy::ComponentTreeAdjustment<float, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+
+            const index_t rootNodeC = mintree.getSmallestComponent(32);
+            REQUIRE(rootNodeC == 150);
+
+            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+            mintree.pruneNode(rootNodeC);
+
+            require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
+    }
+
+    TEST_CASE("component tree adjustment keeps final tree connected and area-consistent", "[component_tree_adjustment]") {
+            // The subtree adjustment must preserve a valid maxtree and keep incremental area exact.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            const std::vector<index_t> referencePixels = {32, 37, 63};
+            for (auto pixelId: referencePixels) {
+                auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+                auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+                detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+                std::vector<double> areaBufferMin;
+                std::vector<double> areaBufferMax;
+                adjust.setAttributeComputer(areaComputer, areaBufferMin, areaBufferMax);
+                areaComputer.computeAttribute(mintree, areaBufferMin);
+                areaComputer.computeAttribute(maxtree, areaBufferMax);
+    
+                const index_t rootNodeC = mintree.getSmallestComponent(pixelId);
+                REQUIRE(rootNodeC == 150);
+                const index_t oldNumNodes = maxtree.getNumNodes();
+
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+    
+                std::vector<double> fullArea;
+                areaComputer.computeAttribute(maxtree, fullArea);
+    
+                INFO("pixelId=" << pixelId);
+                REQUIRE(maxtree.getNumNodes() < oldNumNodes);
+                REQUIRE(maxtree.getNumNodes() == 6);
+                REQUIRE(maxtree.getRoot() == 155);
+                REQUIRE(maxAltitude[(size_t) maxtree.getRoot()] == 3);
+                REQUIRE(area_buffers_equal(maxtree, areaBufferMax, fullArea));
+                REQUIRE(fullArea[(size_t) maxtree.getRoot()] == 144.0);
+                REQUIRE(areaBufferMax[(size_t) maxtree.getRoot()] == 144.0);
+                REQUIRE(maxtree.getNumChildren(155) == 1);
+                REQUIRE(maxtree.getNumChildren(154) == 1);
+                REQUIRE(maxtree.getNumChildren(149) == 2);
+                REQUIRE(maxtree.getNumProperParts(149) == 137);
+                REQUIRE(collect_alive_nodes_by_level(maxtree, maxAltitude) == std::map<int, index_t>{{3, 1}, {4, 1}, {6, 1}, {7, 1}, {8, 2}});
+                require_tree_consistency(maxtree);
+    
+            }
+    }
+
+    TEST_CASE("component tree adjustment also preserves the symmetric maxtree-to-mintree case", "[component_tree_adjustment]") {
+            // The symmetric adjustment must reconnect the final node union under nodeCa when nodeCa survives.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+            detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+            std::vector<double> areaBufferMin;
+            std::vector<double> areaBufferMax;
+            adjust.setAttributeComputer(areaComputer, areaBufferMin, areaBufferMax);
+            areaComputer.computeAttribute(mintree, areaBufferMin);
+            areaComputer.computeAttribute(maxtree, areaBufferMax);
+    
+            const index_t rootNodeC = maxtree.getSmallestComponent(44);
+            REQUIRE(rootNodeC == 150);
+
+            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+    
+            std::vector<double> fullArea;
+            areaComputer.computeAttribute(mintree, fullArea);
+    
+            REQUIRE(mintree.getNumNodes() == 10);
+            REQUIRE(mintree.getRoot() == 153);
+            REQUIRE(minAltitude[(size_t) mintree.getRoot()] == 8);
+            REQUIRE(area_buffers_equal(mintree, areaBufferMin, fullArea));
+            REQUIRE(fullArea[(size_t) mintree.getRoot()] == 144.0);
+            REQUIRE(areaBufferMin[(size_t) mintree.getRoot()] == 144.0);
+            REQUIRE(mintree.getNumChildren(153) == 1);
+            REQUIRE(mintree.getNumChildren(152) == 1);
+            REQUIRE(mintree.getNumChildren(151) == 3);
+            REQUIRE(mintree.hasChild(151, 146));
+            REQUIRE(mintree.hasChild(151, 149));
+            REQUIRE(mintree.hasChild(151, 150));
+            REQUIRE(mintree.getNumChildren(150) == 1);
+            REQUIRE(mintree.hasChild(150, 148));
+            REQUIRE(mintree.getNumChildren(148) == 1);
+            REQUIRE(mintree.hasChild(148, 147));
+            REQUIRE(mintree.getNumChildren(147) == 1);
+            REQUIRE(mintree.hasChild(147, 145));
+            REQUIRE(mintree.getNumChildren(145) == 1);
+            REQUIRE(mintree.hasChild(145, 144));
+            REQUIRE(collect_alive_nodes_by_level(mintree, minAltitude) == std::map<int, index_t>{{1, 1}, {2, 1}, {3, 2}, {4, 2}, {5, 1}, {6, 1}, {7, 1}, {8, 1}});
+            require_tree_consistency(mintree);
+    }
+
+    TEST_CASE("component tree adjustment remains structurally valid on all shared mintree subtree roots", "[component_tree_adjustment]") {
+            // Every shared non-root mintree subtree root should keep the adjusted maxtree connected and area-consistent.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            const std::vector<index_t> sharedMintRoots = {144, 145, 146, 147, 148, 149, 150, 151, 152};
+            for (auto rootNodeC: sharedMintRoots) {
+                auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+                auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+                detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+                std::vector<double> areaBufferMin;
+                std::vector<double> areaBufferMax;
+                adjust.setAttributeComputer(areaComputer, areaBufferMin, areaBufferMax);
+                areaComputer.computeAttribute(mintree, areaBufferMin);
+                areaComputer.computeAttribute(maxtree, areaBufferMax);
+    
+                INFO("mint rootNodeC=" << rootNodeC);
+                REQUIRE(mintree.isAlive(rootNodeC));
+                REQUIRE(maxtree.isAlive(rootNodeC));
+                REQUIRE(!mintree.isRoot(rootNodeC));
+    
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+
+                require_area_consistency(maxtree, areaBufferMax, areaComputer);
+                require_tree_consistency(maxtree);
+                REQUIRE(maxtree.isAlive(maxtree.getRoot()));
+            }
+    }
+
+    TEST_CASE("component tree adjustment remains structurally valid on all shared maxtree subtree roots", "[component_tree_adjustment]") {
+            // Every shared non-root maxtree subtree root should keep the adjusted mintree connected and area-consistent.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            const std::vector<index_t> sharedMaxRoots = {144, 145, 146, 147, 148, 149, 150, 151, 152, 153};
+            for (auto rootNodeC: sharedMaxRoots) {
+                auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+                auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+                detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+                std::vector<double> areaBufferMin;
+                std::vector<double> areaBufferMax;
+                adjust.setAttributeComputer(areaComputer, areaBufferMin, areaBufferMax);
+                areaComputer.computeAttribute(mintree, areaBufferMin);
+                areaComputer.computeAttribute(maxtree, areaBufferMax);
+    
+                INFO("max rootNodeC=" << rootNodeC);
+                REQUIRE(maxtree.isAlive(rootNodeC));
+                REQUIRE(mintree.isAlive(rootNodeC));
+                REQUIRE(!maxtree.isRoot(rootNodeC));
+    
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+
+                require_area_consistency(mintree, areaBufferMin, areaComputer);
+                require_tree_consistency(mintree);
+                REQUIRE(mintree.isAlive(mintree.getRoot()));
+            }
+    }
+
+    TEST_CASE("component tree adjustment rejects subtree roots that are outside complementary-tree bounds", "[component_tree_adjustment]") {
+            // The subtree root id belongs to the source/complementary tree, so its bounds are checked there.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+            const index_t outOfBounds = maxtree.getGlobalIdSpaceSize();
+            bool threw = false;
+            try {
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, outOfBounds);
+            } catch (const std::runtime_error &e) {
+                threw = true;
+                REQUIRE(std::string(e.what()).find("complementary-tree bounds") != std::string::npos);
+            }
+            REQUIRE(threw);
+    }
+
+    TEST_CASE("component tree adjustment rejects subtree roots that are not alive in the complementary tree", "[component_tree_adjustment]") {
+            // A source-tree node id may still map to a dead slot in the complementary tree; this must fail explicitly.
+            auto graph = get_4_adjacency_implicit_graph({12, 12});
+            auto image = make_demo_image();
+    
+            auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
+            auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
+            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            adjust.setAltitudeBuffers(minAltitude, maxAltitude);
+    
+            REQUIRE(maxtree.isAlive(144));
+            REQUIRE(mintree.isAlive(144));
+            mintree.pruneNode(144);
+            REQUIRE(!mintree.isAlive(144));
+    
+            bool threw = false;
+            try {
+                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, 144);
+            } catch (const std::runtime_error &e) {
+                threw = true;
+                REQUIRE(std::string(e.what()).find("valid/alive in complementary tree") != std::string::npos);
+            }
+            REQUIRE(threw);
+    }
+
+} // namespace component_tree_adjustment

--- a/test/cpp/hierarchy/test_component_tree_casf.cpp
+++ b/test/cpp/hierarchy/test_component_tree_casf.cpp
@@ -1,0 +1,487 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "../test_utils.hpp"
+#include <cmath>
+#include <limits>
+
+#include "higra/attribute/tree_attribute.hpp"
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/hierarchy/component_tree_casf.hpp"
+#include "higra/image/graph_image.hpp"
+
+using namespace hg;
+
+namespace component_tree_casf {
+
+    namespace {
+
+        // Returns the shared 12x12 grayscale fixture used by the functional CASF tests.
+        array_1d<uint8_t> make_demo_image() {
+            constexpr index_t numPixels = 144;
+            uint8_t raw[numPixels] = {
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+                    2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+                    6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+                    7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1};
+
+            auto image = array_1d<uint8_t>::from_shape({numPixels});
+            for (index_t i = 0; i < numPixels; ++i) {
+                image(i) = raw[i];
+            }
+            return image;
+        }
+
+        // Structured synthetic image matching the benchmark generator used in the area stress test.
+        array_1d<uint8_t> make_structured_benchmark_image(index_t numRows, index_t numCols) {
+            const index_t numPixels = numRows * numCols;
+            auto image = array_1d<uint8_t>::from_shape({(size_t) numPixels});
+            for (index_t r = 0; r < numRows; ++r) {
+                for (index_t c = 0; c < numCols; ++c) {
+                    const index_t p = r * numCols + c;
+                    const auto value = (37 * r + 19 * c + 11 * ((r / 4) % 7) + 23 * ((c / 8) % 5) + ((r * c) % 29)) % 256;
+                    image(p) = (uint8_t) value;
+                }
+            }
+            return image;
+        }
+
+        template<typename value_t>
+        // Casts the shared fixture to another altitude type while preserving pixel values.
+        array_1d<value_t> make_demo_image_as() {
+            const auto image = make_demo_image();
+            auto out = array_1d<value_t>::from_shape({image.size()});
+            for (index_t i = 0; i < (index_t) image.size(); ++i) {
+                out(i) = (value_t) image(i);
+            }
+            return out;
+        }
+
+        template<typename graph_t>
+        // Builds a dynamic min-tree or max-tree from the given image for internal-selection tests.
+        detail::hierarchy::DynamicComponentTree
+        make_dynamic_tree_from_image(const graph_t &graph, const array_1d<uint8_t> &image, bool isMaxTree) {
+            const auto staticTree = isMaxTree ? component_tree_max_tree(graph, image) : component_tree_min_tree(graph, image);
+            detail::hierarchy::DynamicComponentTree tree;
+            tree.reset(staticTree.tree);
+            return tree;
+        }
+
+        // Tests whether `ancestorId` belongs to the path from `nodeId` to the root.
+        bool is_ancestor(const detail::hierarchy::DynamicComponentTree &tree, index_t ancestorId, index_t nodeId) {
+            for (auto current: tree.getPathToRootNodes(nodeId)) {
+                if (current == ancestorId) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Checks that a selected candidate set is maximal, non-root, and pairwise non-ancestral.
+        void require_candidate_set_valid(const detail::hierarchy::DynamicComponentTree &tree,
+                                         const std::vector<double> &area,
+                                         const std::vector<index_t> &candidates,
+                                         double threshold) {
+            for (auto nodeId: candidates) {
+                REQUIRE(tree.isAlive(nodeId));
+                REQUIRE(!tree.isRoot(nodeId));
+                REQUIRE(area[(size_t) nodeId] <= threshold);
+
+                const auto parentId = tree.getNodeParent(nodeId);
+                REQUIRE(parentId != invalid_index);
+                if (!tree.isRoot(parentId)) {
+                    REQUIRE(area[(size_t) parentId] > threshold);
+                }
+            }
+
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                for (size_t j = i + 1; j < candidates.size(); ++j) {
+                    REQUIRE(!is_ancestor(tree, candidates[i], candidates[j]));
+                    REQUIRE(!is_ancestor(tree, candidates[j], candidates[i]));
+                }
+            }
+        }
+
+        template<typename altitude_t>
+        // Exported trees must respect Higra's static topological ordering convention.
+        void require_higra_topological_order(const tree &staticTree, const xt::xexpression<altitude_t> &xaltitude) {
+            const auto &alt = xaltitude.derived_cast();
+            const index_t n = (index_t) staticTree.num_vertices();
+            const index_t numLeaves = (index_t) staticTree.num_leaves();
+
+            REQUIRE((index_t) alt.size() == n);
+            REQUIRE((index_t) staticTree.root() == n - 1);
+            REQUIRE(staticTree.parent(n - 1) == n - 1);
+
+            for (index_t i = 0; i < n; ++i) {
+                const auto p = staticTree.parent(i);
+                REQUIRE(p >= i);
+                REQUIRE(p < n);
+                if (i < numLeaves) {
+                    REQUIRE(p >= numLeaves);
+                }
+                if (i != n - 1) {
+                    REQUIRE(p > i);
+                }
+            }
+        }
+
+        template<typename altitude_t, typename graph_t>
+        // Exported trees must match a fresh static component-tree rebuild from the filtered image.
+        void require_export_matches_component_tree(const typename ComponentTreeCasf<altitude_t, graph_t>::ExportedTree &exported,
+                                                   const graph_t &graph,
+                                                   const array_1d<altitude_t> &filteredImage,
+                                                   bool isMaxTree) {
+            const auto expected = isMaxTree ? component_tree_max_tree(graph, filteredImage)
+                                            : component_tree_min_tree(graph, filteredImage);
+            require_higra_topological_order(exported.tree, exported.altitudes);
+            REQUIRE((exported.tree.parents() == expected.tree.parents()));
+            REQUIRE((exported.altitudes == expected.altitudes));
+        }
+
+        template<typename image_t, typename graph_t>
+        // Applies one naive area-based CASF step by rebuilding the max-tree and min-tree from scratch.
+        image_t apply_naive_threshold_by_area(const graph_t &graph, const image_t &image, double threshold) {
+            auto maxTree = component_tree_max_tree(graph, image);
+            auto maxArea = attribute_area(maxTree.tree);
+            auto filtered = reconstruct_leaf_data(maxTree.tree, maxTree.altitudes, maxArea <= threshold);
+
+            auto minTree = component_tree_min_tree(graph, filtered);
+            auto minArea = attribute_area(minTree.tree);
+            return reconstruct_leaf_data(minTree.tree, minTree.altitudes, minArea <= threshold);
+        }
+
+        template<typename image_t, typename graph_t>
+        // Runs the full naive area-based threshold sequence used as a functional reference.
+        image_t run_naive_area_sequence(const graph_t &graph, const image_t &image, const std::vector<double> &thresholds) {
+            image_t current = image;
+            for (double threshold: thresholds) {
+                current = apply_naive_threshold_by_area(graph, current, threshold);
+            }
+            return current;
+        }
+
+        // Computes a static-tree bounding-box attribute with an explicit bottom-up reference implementation.
+        template<typename tree_t, typename graph_t>
+        auto compute_naive_bounding_box_attribute(const tree_t &tree,
+                                                  const graph_t &graph,
+                                                  detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure measure) {
+            auto treeWithChildren = tree;
+            treeWithChildren.compute_children();
+
+            std::vector<index_t> xmin((size_t) treeWithChildren.num_vertices(), std::numeric_limits<index_t>::max());
+            std::vector<index_t> xmax((size_t) treeWithChildren.num_vertices(), std::numeric_limits<index_t>::lowest());
+            std::vector<index_t> ymin((size_t) treeWithChildren.num_vertices(), std::numeric_limits<index_t>::max());
+            std::vector<index_t> ymax((size_t) treeWithChildren.num_vertices(), std::numeric_limits<index_t>::lowest());
+            std::vector<bool> empty((size_t) treeWithChildren.num_vertices(), true);
+            array_1d<double> attribute = xt::zeros<double>({treeWithChildren.num_vertices()});
+
+            for (index_t leaf = 0; leaf < (index_t) treeWithChildren.num_leaves(); ++leaf) {
+                const auto point = graph.embedding().lin2grid(leaf);
+                const auto y = (index_t) point[0];
+                const auto x = (index_t) point[1];
+                xmin[(size_t) leaf] = x;
+                xmax[(size_t) leaf] = x;
+                ymin[(size_t) leaf] = y;
+                ymax[(size_t) leaf] = y;
+                empty[(size_t) leaf] = false;
+            }
+
+            for (auto node: leaves_to_root_iterator(treeWithChildren, leaves_it::exclude)) {
+                for (auto child: children_iterator(node, treeWithChildren)) {
+                    if (empty[(size_t) child]) {
+                        continue;
+                    }
+                    if (empty[(size_t) node]) {
+                        xmin[(size_t) node] = xmin[(size_t) child];
+                        xmax[(size_t) node] = xmax[(size_t) child];
+                        ymin[(size_t) node] = ymin[(size_t) child];
+                        ymax[(size_t) node] = ymax[(size_t) child];
+                        empty[(size_t) node] = false;
+                    } else {
+                        xmin[(size_t) node] = std::min(xmin[(size_t) node], xmin[(size_t) child]);
+                        xmax[(size_t) node] = std::max(xmax[(size_t) node], xmax[(size_t) child]);
+                        ymin[(size_t) node] = std::min(ymin[(size_t) node], ymin[(size_t) child]);
+                        ymax[(size_t) node] = std::max(ymax[(size_t) node], ymax[(size_t) child]);
+                    }
+                }
+            }
+
+            for (index_t node = 0; node < (index_t) treeWithChildren.num_vertices(); ++node) {
+                if (empty[(size_t) node]) {
+                    attribute(node) = 0.0;
+                    continue;
+                }
+                const double width = (double) (xmax[(size_t) node] - xmin[(size_t) node] + 1);
+                const double height = (double) (ymax[(size_t) node] - ymin[(size_t) node] + 1);
+                switch (measure) {
+                    case detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::width:
+                        attribute(node) = width;
+                        break;
+                    case detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::height:
+                        attribute(node) = height;
+                        break;
+                    case detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::diagonal_length:
+                        attribute(node) = std::sqrt(width * width + height * height);
+                        break;
+                }
+            }
+
+            return attribute;
+        }
+
+        template<typename image_t, typename graph_t>
+        // Applies one naive bounding-box-based CASF step by rebuilding both trees from scratch.
+        image_t apply_naive_threshold_by_bounding_box(const graph_t &graph,
+                                                      const image_t &image,
+                                                      double threshold,
+                                                      detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure measure) {
+            auto maxTree = component_tree_max_tree(graph, image);
+            auto maxAttribute = compute_naive_bounding_box_attribute(maxTree.tree, graph, measure);
+            auto filtered = reconstruct_leaf_data(maxTree.tree, maxTree.altitudes, maxAttribute <= threshold);
+
+            auto minTree = component_tree_min_tree(graph, filtered);
+            auto minAttribute = compute_naive_bounding_box_attribute(minTree.tree, graph, measure);
+            return reconstruct_leaf_data(minTree.tree, minTree.altitudes, minAttribute <= threshold);
+        }
+
+        template<typename image_t, typename graph_t>
+        // Runs the full naive bounding-box threshold sequence used as a functional reference.
+        image_t run_naive_bounding_box_sequence(const graph_t &graph,
+                                                const image_t &image,
+                                                const std::vector<double> &thresholds,
+                                                detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure measure) {
+            image_t current = image;
+            for (double threshold: thresholds) {
+                current = apply_naive_threshold_by_bounding_box(graph, current, threshold, measure);
+            }
+            return current;
+        }
+
+        // Generates increasing area thresholds spanning the image domain for the stress test.
+        std::vector<double> make_area_thresholds(index_t numPixels, int numThresholds) {
+            std::vector<double> thresholds;
+            thresholds.reserve((size_t) numThresholds);
+            for (int step = 1; step <= numThresholds; ++step) {
+                const double ratio = (double) step / (double) (numThresholds + 1);
+                const auto threshold = (double) std::max<index_t>(1, (index_t) std::llround(ratio * (double) numPixels));
+                if (thresholds.empty() || threshold > thresholds.back()) {
+                    thresholds.push_back(threshold);
+                }
+            }
+            return thresholds;
+        }
+
+    } // namespace
+
+    TEST_CASE("component tree CASF filter exports max-tree and min-tree in Higra static form", "[component_tree_casf]") {
+        // Export must coincide with rebuilding the static min-tree and max-tree from the filtered image.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        const std::vector<double> thresholds{15.0, 100.0};
+
+        ComponentTreeCasf<uint8_t, decltype(graph)> casf(graph, image);
+        const auto filtered = casf.filter(thresholds);
+        const auto exportedMax = casf.exportMaxTree();
+        const auto exportedMin = casf.exportMinTree();
+
+        require_export_matches_component_tree<uint8_t>(exportedMax, graph, filtered, true);
+        require_export_matches_component_tree<uint8_t>(exportedMin, graph, filtered, false);
+    }
+
+    TEST_CASE("component tree CASF export remains valid for all supported attribute choices", "[component_tree_casf]") {
+        // Changing the selection attribute must not break the structural validity of the exported trees.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        const std::vector<double> thresholds{3.0, 5.0};
+
+        for (auto attribute: {ComponentTreeCasfAttribute::area,
+                              ComponentTreeCasfAttribute::bounding_box_width,
+                              ComponentTreeCasfAttribute::bounding_box_height,
+                              ComponentTreeCasfAttribute::bounding_box_diagonal}) {
+            INFO("attribute=" << (int) attribute);
+            ComponentTreeCasf<uint8_t, decltype(graph)> casf(graph, image, attribute);
+            const auto filtered = casf.filter(thresholds);
+            const auto exportedMax = casf.exportMaxTree();
+            const auto exportedMin = casf.exportMinTree();
+
+            require_export_matches_component_tree<uint8_t>(exportedMax, graph, filtered, true);
+            require_export_matches_component_tree<uint8_t>(exportedMin, graph, filtered, false);
+        }
+    }
+
+    TEST_CASE("component tree CASF is deterministic across independent instances", "[component_tree_casf]") {
+        // Two independent instances started from the same input must produce the same filtered state and exports.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        const std::vector<double> thresholds{15.0, 100.0};
+
+        ComponentTreeCasf<uint8_t, decltype(graph)> casf1(graph, image);
+        ComponentTreeCasf<uint8_t, decltype(graph)> casf2(graph, image);
+        const auto first = casf1.filter(thresholds);
+        const auto firstMax = casf1.exportMaxTree();
+        const auto firstMin = casf1.exportMinTree();
+
+        const auto second = casf2.filter(thresholds);
+        const auto secondMax = casf2.exportMaxTree();
+        const auto secondMin = casf2.exportMinTree();
+
+        REQUIRE((first == second));
+        REQUIRE((firstMax.tree.parents() == secondMax.tree.parents()));
+        REQUIRE((firstMax.altitudes == secondMax.altitudes));
+        REQUIRE((firstMin.tree.parents() == secondMin.tree.parents()));
+        REQUIRE((firstMin.altitudes == secondMin.altitudes));
+    }
+
+    TEST_CASE("component tree CASF empty threshold sequence preserves the current state and exports", "[component_tree_casf]") {
+        // An empty sequence must leave the current filtered state unchanged.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        const std::vector<double> firstThresholds{15.0, 100.0};
+        const std::vector<double> emptyThresholds{};
+
+        ComponentTreeCasf<uint8_t, decltype(graph)> casf(graph, image);
+        const auto before = casf.filter(firstThresholds);
+        const auto beforeMax = casf.exportMaxTree();
+        const auto beforeMin = casf.exportMinTree();
+        const auto after = casf.filter(emptyThresholds);
+        const auto afterMax = casf.exportMaxTree();
+        const auto afterMin = casf.exportMinTree();
+
+        REQUIRE((after == before));
+        REQUIRE((beforeMax.tree.parents() == afterMax.tree.parents()));
+        REQUIRE((beforeMax.altitudes == afterMax.altitudes));
+        REQUIRE((beforeMin.tree.parents() == afterMin.tree.parents()));
+        REQUIRE((beforeMin.altitudes == afterMin.altitudes));
+    }
+
+    TEST_CASE("component tree CASF dense and sparse backends reconstruct the same filtered image", "[component_tree_casf]") {
+        // Dense integral and sparse floating-point backends must agree on the filtered image.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto imageUInt8 = make_demo_image();
+        auto imageFloat = make_demo_image_as<float>();
+        const std::vector<double> thresholds{15.0, 100.0};
+
+        ComponentTreeCasf<uint8_t, decltype(graph)> casfUInt8(graph, imageUInt8);
+        ComponentTreeCasf<float, decltype(graph)> casfFloat(graph, imageFloat);
+        const auto resultUInt8 = casfUInt8.filter(thresholds);
+        const auto resultFloat = casfFloat.filter(thresholds);
+
+        REQUIRE(resultUInt8.size() == resultFloat.size());
+        for (index_t i = 0; i < (index_t) resultUInt8.size(); ++i) {
+            REQUIRE((float) resultUInt8(i) == resultFloat(i));
+        }
+    }
+
+    TEST_CASE("component tree CASF bounding-box attributes match a naive reference sequence", "[component_tree_casf]") {
+        // Bounding-box-driven pruning must match a full rebuild reference for each supported measure.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+
+        struct Case {
+            ComponentTreeCasfAttribute casfAttribute;
+            detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure measure;
+        };
+
+        const std::vector<double> thresholds{2.0, 4.0, 6.0};
+
+        for (const auto &testCase: {
+                Case{ComponentTreeCasfAttribute::bounding_box_width, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::width},
+                Case{ComponentTreeCasfAttribute::bounding_box_height, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::height},
+                Case{ComponentTreeCasfAttribute::bounding_box_diagonal, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::diagonal_length}}) {
+            INFO("attribute=" << (int) testCase.casfAttribute);
+            const auto expected = run_naive_bounding_box_sequence(graph, image, thresholds, testCase.measure);
+
+            ComponentTreeCasf<uint8_t, decltype(graph)> casf(graph, image, testCase.casfAttribute);
+            const auto actual = casf.filter(thresholds);
+            const auto exportedMax = casf.exportMaxTree();
+            const auto exportedMin = casf.exportMinTree();
+
+            REQUIRE((actual == expected));
+            require_export_matches_component_tree<uint8_t>(exportedMax, graph, actual, true);
+            require_export_matches_component_tree<uint8_t>(exportedMin, graph, actual, false);
+        }
+    }
+
+    TEST_CASE("component tree CASF area-based selection matches the reference maxtree thresholds", "[component_tree_casf]") {
+        // The BFS threshold selection must follow the same pruning-root semantics used in MorphoTreeAdjust.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        auto maxtree = make_dynamic_tree_from_image(graph, image, true);
+        detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+        std::vector<double> area;
+        areaComputer.computeAttribute(maxtree, area);
+
+        using casf_t = ComponentTreeCasf<uint8_t, decltype(graph)>;
+        casf_t casf(graph, image);
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, 1.0), std::vector<index_t>{150, 145, 146, 144}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, 14.0), std::vector<index_t>{152, 154, 149, 145, 146}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, 15.0), std::vector<index_t>{152, 155, 151, 153}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, 100.0), std::vector<index_t>{152, 155, 156}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, 144.0), std::vector<index_t>{157}));
+
+        for (double threshold: {1.0, 14.0, 15.0, 100.0, 144.0}) {
+            INFO("threshold=" << threshold);
+            require_candidate_set_valid(maxtree, area, testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, maxtree, area, threshold), threshold);
+        }
+    }
+
+    TEST_CASE("component tree CASF area-based selection matches the reference mintree thresholds", "[component_tree_casf]") {
+        // The same threshold rule must work symmetrically on the mintree.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        auto mintree = make_dynamic_tree_from_image(graph, image, false);
+        detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+        std::vector<double> area;
+        areaComputer.computeAttribute(mintree, area);
+
+        using casf_t = ComponentTreeCasf<uint8_t, decltype(graph)>;
+        casf_t casf(graph, image);
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, mintree, area, 1.0), std::vector<index_t>{146, 149}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, mintree, area, 40.0), std::vector<index_t>{146, 149, 144}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, mintree, area, 100.0), std::vector<index_t>{146, 149, 147}));
+        REQUIRE(vectorEqual(testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, mintree, area, 144.0), std::vector<index_t>{152}));
+
+        for (double threshold: {1.0, 40.0, 100.0, 144.0}) {
+            INFO("threshold=" << threshold);
+            require_candidate_set_valid(mintree, area, testing::ComponentTreeCasfTestAccess::selectPruneCandidates(casf, mintree, area, threshold), threshold);
+        }
+    }
+
+    TEST_CASE("component tree CASF stress test matches the naive area sequence on the structured benchmark image", "[component_tree_casf]") {
+        // Stress test the CASF correctness on the structured benchmark pattern across multiple image sizes.
+        for (const index_t size: {32, 64, 128, 256, 512, 1014}) {
+            INFO("size=" << size);
+            auto graph = get_4_adjacency_implicit_graph({size, size});
+            auto image = make_structured_benchmark_image(size, size);
+            const auto thresholds = make_area_thresholds(size * size, 10);
+
+            const auto expected = run_naive_area_sequence(graph, image, thresholds);
+
+            ComponentTreeCasf<uint8_t, decltype(graph)> casf(graph, image);
+            const auto actual = casf.filter(thresholds);
+            const auto exportedMax = casf.exportMaxTree();
+            const auto exportedMin = casf.exportMinTree();
+
+            REQUIRE((actual == expected));
+            require_export_matches_component_tree<uint8_t>(exportedMax, graph, actual, true);
+            require_export_matches_component_tree<uint8_t>(exportedMin, graph, actual, false);
+        }
+    }
+
+} // namespace component_tree_casf

--- a/test/cpp/hierarchy/test_component_tree_casf.cpp
+++ b/test/cpp/hierarchy/test_component_tree_casf.cpp
@@ -142,7 +142,7 @@ namespace component_tree_casf {
         }
 
         template<typename altitude_t, typename graph_t>
-        // Exported trees must match a fresh static component-tree rebuild from the filtered image.
+        // Exported trees must match a fresh static component tree rebuild from the filtered image.
         void require_export_matches_component_tree(const typename ComponentTreeCasf<altitude_t, graph_t>::ExportedTree &exported,
                                                    const graph_t &graph,
                                                    const array_1d<altitude_t> &filteredImage,
@@ -419,7 +419,8 @@ namespace component_tree_casf {
     }
 
     TEST_CASE("component tree CASF area-based selection matches the reference maxtree thresholds", "[component_tree_casf]") {
-        // The BFS threshold selection must follow the same pruning-root semantics used in MorphoTreeAdjust.
+        // The breadth-first threshold selection must return maximal non-root
+        // candidates, as in MorphoTreeAdjust.
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         auto maxtree = make_dynamic_tree_from_image(graph, image, true);
@@ -442,7 +443,7 @@ namespace component_tree_casf {
     }
 
     TEST_CASE("component tree CASF area-based selection matches the reference mintree thresholds", "[component_tree_casf]") {
-        // The same threshold rule must work symmetrically on the mintree.
+        // The same threshold rule must work symmetrically on the min-tree.
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         auto mintree = make_dynamic_tree_from_image(graph, image, false);

--- a/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
+++ b/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
@@ -198,6 +198,8 @@ namespace {
                     REQUIRE(tree.hasChild(nodeId, childId));
                 }
 
+                REQUIRE(tree.getNumProperParts(nodeId) > 0);
+
                 index_t countedProperParts = 0;
                 for (auto p: tree.getProperParts(nodeId)) {
                     REQUIRE(tree.isProperPart(p));
@@ -356,7 +358,7 @@ namespace {
     
                 INFO("pixelId=" << pixelId);
                 REQUIRE(maxtree.getNumNodes() < oldNumNodes);
-                REQUIRE(maxtree.getNumNodes() == 6);
+                REQUIRE(maxtree.getNumNodes() == 7);
                 REQUIRE(maxtree.getRoot() == 155);
                 REQUIRE(maxAltitude[(size_t) maxtree.getRoot()] == 3);
                 REQUIRE(area_buffers_equal(maxtree, areaBufferMax, fullArea));
@@ -364,9 +366,9 @@ namespace {
                 REQUIRE(areaBufferMax[(size_t) maxtree.getRoot()] == 144.0);
                 REQUIRE(maxtree.getNumChildren(155) == 1);
                 REQUIRE(maxtree.getNumChildren(154) == 1);
-                REQUIRE(maxtree.getNumChildren(149) == 2);
+                REQUIRE(maxtree.getNumChildren(149) == 3);
                 REQUIRE(maxtree.getNumProperParts(149) == 137);
-                REQUIRE(collect_alive_nodes_by_level(maxtree, maxAltitude) == std::map<int, index_t>{{3, 1}, {4, 1}, {6, 1}, {7, 1}, {8, 2}});
+                REQUIRE(collect_alive_nodes_by_level(maxtree, maxAltitude) == std::map<int, index_t>{{3, 1}, {4, 1}, {6, 1}, {7, 1}, {8, 3}});
                 require_tree_consistency(maxtree);
     
             }
@@ -485,8 +487,8 @@ namespace {
             }
     }
 
-    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are outside complementary-tree bounds", "[dual_min_max_tree_incremental_filter]") {
-            // The subtree root id belongs to the source/complementary tree, so its bounds are checked there.
+    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are outside primal-tree bounds", "[dual_min_max_tree_incremental_filter]") {
+            // The subtree root id belongs to the source/primal tree, so its bounds are checked there.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
@@ -501,13 +503,13 @@ namespace {
                 DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &mintree, outOfBounds);
             } catch (const std::runtime_error &e) {
                 threw = true;
-                REQUIRE(std::string(e.what()).find("complementary-tree bounds") != std::string::npos);
+                REQUIRE(std::string(e.what()).find("primal-tree bounds") != std::string::npos);
             }
             REQUIRE(threw);
     }
 
-    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are not alive in the complementary tree", "[dual_min_max_tree_incremental_filter]") {
-            // A source-tree node id may still map to a dead slot in the complementary tree; this must fail explicitly.
+    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are not alive in the primal tree", "[dual_min_max_tree_incremental_filter]") {
+            // A source-tree node id may still map to a dead slot in the primal tree; this must fail explicitly.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
@@ -526,7 +528,7 @@ namespace {
                 DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, 144);
             } catch (const std::runtime_error &e) {
                 threw = true;
-                REQUIRE(std::string(e.what()).find("valid/alive in complementary tree") != std::string::npos);
+                REQUIRE(std::string(e.what()).find("valid/alive in primal tree") != std::string::npos);
             }
             REQUIRE(threw);
     }

--- a/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
+++ b/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
@@ -9,7 +9,7 @@
 ****************************************************************************/
 
 #include "../test_utils.hpp"
-#include "higra/detail/hierarchy/component_tree_adjustment.hpp"
+#include "higra/detail/hierarchy/dual_min_max_tree_incremental_filter.hpp"
 #include "higra/detail/hierarchy/dynamic_component_tree.hpp"
 #include "higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp"
 #include "higra/hierarchy/component_tree.hpp"
@@ -18,9 +18,9 @@
 
 using namespace hg;
 
-namespace component_tree_adjustment {
+namespace dual_min_max_tree_incremental_filter {
 
-using detail::hierarchy::testing::ComponentTreeAdjustmentTestAccess;
+using detail::hierarchy::testing::DualMinMaxTreeIncrementalFilterTestAccess;
 
 namespace {
 
@@ -241,49 +241,49 @@ namespace {
 
     } // namespace
 
-    TEST_CASE("component tree adjustment maxtree update matches the rebuild image baseline after mintree pruning", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter maxtree update matches the rebuild image baseline after mintree pruning", "[dual_min_max_tree_incremental_filter]") {
             // The updated maxtree must represent the same filtered image as a prune-then-rebuild baseline.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
 
             const index_t rootNodeC = mintree.getSmallestComponent(32);
             REQUIRE(rootNodeC == 150);
 
-            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+            DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, rootNodeC);
             mintree.pruneNode(rootNodeC);
 
             require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
     }
 
-    TEST_CASE("component tree adjustment mintree update matches the rebuild image baseline after maxtree pruning", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter mintree update matches the rebuild image baseline after maxtree pruning", "[dual_min_max_tree_incremental_filter]") {
             // The symmetric update must represent the same filtered image as a prune-then-rebuild baseline.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
 
             const index_t rootNodeC = maxtree.getSmallestComponent(44);
             REQUIRE(rootNodeC == 150);
 
-            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+            DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &mintree, rootNodeC);
             maxtree.pruneNode(rootNodeC);
 
             require_tree_matches_rebuilt_image_baseline(mintree, minAltitude, maxtree, maxAltitude);
     }
 
-    TEST_CASE("component tree adjustment matches the rebuild image baseline across sequential mintree prunes", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter matches the rebuild image baseline across sequential mintree prunes", "[dual_min_max_tree_incremental_filter]") {
             // Reusing the same adjustment helper across multiple rounds must stay equivalent to repeated prune-then-rebuild baselines.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
 
             for (const index_t pixelId: std::vector<index_t>{32, 82}) {
@@ -293,14 +293,14 @@ namespace {
                 REQUIRE(mintree.isAlive(rootNodeC));
                 REQUIRE(!mintree.isRoot(rootNodeC));
 
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, rootNodeC);
                 mintree.pruneNode(rootNodeC);
 
                 require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
             }
     }
 
-    TEST_CASE("component tree adjustment sparse backend matches the rebuild image baseline on non-integral float altitudes", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter sparse backend matches the rebuild image baseline on non-integral float altitudes", "[dual_min_max_tree_incremental_filter]") {
             // The sparse backend must represent the same filtered image as a prune-then-rebuild baseline on non-integral levels.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image_non_integral_float();
@@ -314,19 +314,19 @@ namespace {
             std::vector<float> maxAltitude(staticMaxTree.altitudes.begin(), staticMaxTree.altitudes.end());
             std::vector<float> minAltitude(staticMinTree.altitudes.begin(), staticMinTree.altitudes.end());
 
-            detail::hierarchy::ComponentTreeAdjustment<float, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<float, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
 
             const index_t rootNodeC = mintree.getSmallestComponent(32);
             REQUIRE(rootNodeC == 150);
 
-            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+            DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, rootNodeC);
             mintree.pruneNode(rootNodeC);
 
             require_tree_matches_rebuilt_image_baseline(maxtree, maxAltitude, mintree, minAltitude);
     }
 
-    TEST_CASE("component tree adjustment keeps final tree connected and area-consistent", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter keeps final tree connected and area-consistent", "[dual_min_max_tree_incremental_filter]") {
             // The subtree adjustment must preserve a valid maxtree and keep incremental area exact.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
@@ -335,7 +335,7 @@ namespace {
             for (auto pixelId: referencePixels) {
                 auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
                 auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
                 adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
                 detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
@@ -349,7 +349,7 @@ namespace {
                 REQUIRE(rootNodeC == 150);
                 const index_t oldNumNodes = maxtree.getNumNodes();
 
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, rootNodeC);
     
                 std::vector<double> fullArea;
                 areaComputer.computeAttribute(maxtree, fullArea);
@@ -372,14 +372,14 @@ namespace {
             }
     }
 
-    TEST_CASE("component tree adjustment also preserves the symmetric maxtree-to-mintree case", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter also preserves the symmetric maxtree-to-mintree case", "[dual_min_max_tree_incremental_filter]") {
             // The symmetric adjustment must reconnect the final node union under nodeCa when nodeCa survives.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
             detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
@@ -392,7 +392,7 @@ namespace {
             const index_t rootNodeC = maxtree.getSmallestComponent(44);
             REQUIRE(rootNodeC == 150);
 
-            ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+            DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &mintree, rootNodeC);
     
             std::vector<double> fullArea;
             areaComputer.computeAttribute(mintree, fullArea);
@@ -421,7 +421,7 @@ namespace {
             require_tree_consistency(mintree);
     }
 
-    TEST_CASE("component tree adjustment remains structurally valid on all shared mintree subtree roots", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter remains structurally valid on all shared mintree subtree roots", "[dual_min_max_tree_incremental_filter]") {
             // Every shared non-root mintree subtree root should keep the adjusted maxtree connected and area-consistent.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
@@ -430,7 +430,7 @@ namespace {
             for (auto rootNodeC: sharedMintRoots) {
                 auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
                 auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
                 adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
                 detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
@@ -445,7 +445,7 @@ namespace {
                 REQUIRE(maxtree.isAlive(rootNodeC));
                 REQUIRE(!mintree.isRoot(rootNodeC));
     
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, rootNodeC);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, rootNodeC);
 
                 require_area_consistency(maxtree, areaBufferMax, areaComputer);
                 require_tree_consistency(maxtree);
@@ -453,7 +453,7 @@ namespace {
             }
     }
 
-    TEST_CASE("component tree adjustment remains structurally valid on all shared maxtree subtree roots", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter remains structurally valid on all shared maxtree subtree roots", "[dual_min_max_tree_incremental_filter]") {
             // Every shared non-root maxtree subtree root should keep the adjusted mintree connected and area-consistent.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
@@ -462,7 +462,7 @@ namespace {
             for (auto rootNodeC: sharedMaxRoots) {
                 auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
                 auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-                detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+                detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
                 adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
                 detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
@@ -477,7 +477,7 @@ namespace {
                 REQUIRE(mintree.isAlive(rootNodeC));
                 REQUIRE(!maxtree.isRoot(rootNodeC));
     
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, rootNodeC);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &mintree, rootNodeC);
 
                 require_area_consistency(mintree, areaBufferMin, areaComputer);
                 require_tree_consistency(mintree);
@@ -485,20 +485,20 @@ namespace {
             }
     }
 
-    TEST_CASE("component tree adjustment rejects subtree roots that are outside complementary-tree bounds", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are outside complementary-tree bounds", "[dual_min_max_tree_incremental_filter]") {
             // The subtree root id belongs to the source/complementary tree, so its bounds are checked there.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
             const index_t outOfBounds = maxtree.getGlobalIdSpaceSize();
             bool threw = false;
             try {
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &mintree, outOfBounds);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &mintree, outOfBounds);
             } catch (const std::runtime_error &e) {
                 threw = true;
                 REQUIRE(std::string(e.what()).find("complementary-tree bounds") != std::string::npos);
@@ -506,14 +506,14 @@ namespace {
             REQUIRE(threw);
     }
 
-    TEST_CASE("component tree adjustment rejects subtree roots that are not alive in the complementary tree", "[component_tree_adjustment]") {
+    TEST_CASE("dual min max tree incremental filter rejects subtree roots that are not alive in the complementary tree", "[dual_min_max_tree_incremental_filter]") {
             // A source-tree node id may still map to a dead slot in the complementary tree; this must fail explicitly.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
             auto [mintree, minAltitude] = make_component_tree_with_altitude(graph, image, false);
-            detail::hierarchy::ComponentTreeAdjustment<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
+            detail::hierarchy::DualMinMaxTreeIncrementalFilter<uint8_t, decltype(graph)> adjust(&mintree, &maxtree, graph);
             adjust.setAltitudeBuffers(minAltitude, maxAltitude);
     
             REQUIRE(maxtree.isAlive(144));
@@ -523,7 +523,7 @@ namespace {
     
             bool threw = false;
             try {
-                ComponentTreeAdjustmentTestAccess::updateTree(adjust, &maxtree, 144);
+                DualMinMaxTreeIncrementalFilterTestAccess::updateTree(adjust, &maxtree, 144);
             } catch (const std::runtime_error &e) {
                 threw = true;
                 REQUIRE(std::string(e.what()).find("valid/alive in complementary tree") != std::string::npos);
@@ -531,4 +531,4 @@ namespace {
             REQUIRE(threw);
     }
 
-} // namespace component_tree_adjustment
+} // namespace dual_min_max_tree_incremental_filter

--- a/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
+++ b/test/cpp/hierarchy/test_dual_min_max_tree_incremental_filter.cpp
@@ -94,9 +94,9 @@ namespace {
         }
 
         /*
-         * Reference maxtree and mintree for the 12x12 demo image.
+         * Reference max-tree and min-tree for the 12x12 demo image.
          *
-         * == Dynamic maxtree ==
+         * == Dynamic max-tree ==
          * └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
          *    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143],
          *    ProperPartCount: 22
@@ -122,7 +122,7 @@ namespace {
          *             ├──ID: 145, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [117], ProperPartCount: 1
          *             └──ID: 146, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [115], ProperPartCount: 1
          *
-         * == Dynamic mintree ==
+         * == Dynamic min-tree ==
          * └──ID: 153, Parent: 153, Altitude: 8, NumChildren: 1, ProperParts: [115, 117, 121], ProperPartCount: 3
          *    └──ID: 152, Parent: 153, Altitude: 7, NumChildren: 1, ProperParts: [108, 120], ProperPartCount: 2
          *       └──ID: 151, Parent: 152, Altitude: 6, NumChildren: 3,
@@ -244,7 +244,7 @@ namespace {
     } // namespace
 
     TEST_CASE("dual min max tree incremental filter maxtree update matches the rebuild image baseline after mintree pruning", "[dual_min_max_tree_incremental_filter]") {
-            // The updated maxtree must represent the same filtered image as a prune-then-rebuild baseline.
+            // The updated max-tree must represent the same filtered image as a prune-then-rebuild baseline.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
             auto [maxtree, maxAltitude] = make_component_tree_with_altitude(graph, image, true);
@@ -329,7 +329,7 @@ namespace {
     }
 
     TEST_CASE("dual min max tree incremental filter keeps final tree connected and area-consistent", "[dual_min_max_tree_incremental_filter]") {
-            // The subtree adjustment must preserve a valid maxtree and keep incremental area exact.
+            // The subtree adjustment must preserve a valid max-tree and keep incremental area exact.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
@@ -375,7 +375,7 @@ namespace {
     }
 
     TEST_CASE("dual min max tree incremental filter also preserves the symmetric maxtree-to-mintree case", "[dual_min_max_tree_incremental_filter]") {
-            // The symmetric adjustment must reconnect the final node union under nodeCa when nodeCa survives.
+            // The symmetric adjustment must reconnect the final merged node under nodeCa when nodeCa survives.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
@@ -424,7 +424,8 @@ namespace {
     }
 
     TEST_CASE("dual min max tree incremental filter remains structurally valid on all shared mintree subtree roots", "[dual_min_max_tree_incremental_filter]") {
-            // Every shared non-root mintree subtree root should keep the adjusted maxtree connected and area-consistent.
+            // Every shared non-root min-tree subtree root should keep the adjusted
+            // max-tree connected and area-consistent.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     
@@ -456,7 +457,8 @@ namespace {
     }
 
     TEST_CASE("dual min max tree incremental filter remains structurally valid on all shared maxtree subtree roots", "[dual_min_max_tree_incremental_filter]") {
-            // Every shared non-root maxtree subtree root should keep the adjusted mintree connected and area-consistent.
+            // Every shared non-root max-tree subtree root should keep the adjusted
+            // min-tree connected and area-consistent.
             auto graph = get_4_adjacency_implicit_graph({12, 12});
             auto image = make_demo_image();
     

--- a/test/cpp/hierarchy/test_dynamic_component_tree.cpp
+++ b/test/cpp/hierarchy/test_dynamic_component_tree.cpp
@@ -1,0 +1,560 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "../test_utils.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/image/graph_image.hpp"
+
+
+/*
+* Reference dynamic maxtree:
+*      
+*               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+*               2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+*    image  =   2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+*               3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+*               2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+*               6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+*               7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+*               7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+*               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1
+* 
+* Dynamic maxtree:
+* └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
+*    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143], ProperPartCount: 22
+*    └──ID: 157, Parent: 158, Altitude: 2, NumChildren: 3,
+*       ProperParts: [0, 1, 2, 3, 4, 5, 12, 19, 20, 21, 24, 31, 33, 36, 43, 45, 48, 55, 57, 60, 67, 68, 69, 84, 85, 86, 87, 88, 89, 101, 113, 125, 132, 133, 134, 135, 136, 137], ProperPartCount: 38
+*       ├──ID: 152, Parent: 157, Altitude: 5, NumChildren: 1, ProperParts: [32, 56], ProperPartCount: 2
+*       │  └──ID: 150, Parent: 152, Altitude: 6, NumChildren: 0, ProperParts: [44], ProperPartCount: 1
+*       ├──ID: 155, Parent: 157, Altitude: 3, NumChildren: 1, ProperParts: [109], ProperPartCount: 1
+*       │  └──ID: 154, Parent: 155, Altitude: 4, NumChildren: 1, ProperParts: [111], ProperPartCount: 1
+*       │     └──ID: 148, Parent: 154, Altitude: 6, NumChildren: 1,
+*       │        ProperParts: [96, 97, 98, 99, 100, 110, 112, 122, 123, 124], ProperPartCount: 10
+*       │        └──ID: 147, Parent: 148, Altitude: 7, NumChildren: 1, ProperParts: [108, 120], ProperPartCount: 2
+*       │           └──ID: 144, Parent: 147, Altitude: 8, NumChildren: 0, ProperParts: [121], ProperPartCount: 1
+*       └──ID: 156, Parent: 157, Altitude: 3, NumChildren: 2,
+*          ProperParts: [16, 17, 18, 22, 28, 29, 30, 34, 40, 41, 42, 46, 52, 53, 54, 58, 64, 65, 66, 70, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 90, 91, 92, 93, 94], ProperPartCount: 36
+*          ├──ID: 151, Parent: 156, Altitude: 5, NumChildren: 1,
+*          │  ProperParts: [13, 14, 15, 25, 27, 37, 39, 49, 51, 61, 62, 63], ProperPartCount: 12
+*          │  └──ID: 149, Parent: 151, Altitude: 6, NumChildren: 0, ProperParts: [26, 38, 50], ProperPartCount: 3
+*          └──ID: 153, Parent: 156, Altitude: 4, NumChildren: 2,
+*             ProperParts: [102, 103, 104, 105, 106, 114, 116, 118, 126, 127, 128, 129, 130], ProperPartCount: 13
+*             ├──ID: 145, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [117], ProperPartCount: 1
+*             └──ID: 146, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [115], ProperPartCount: 1
+*/
+
+
+using namespace hg;
+
+namespace dynamic_component_tree {
+
+    namespace {
+
+
+        using tree_t = DynamicComponentTree<uint8_t>;
+
+        constexpr bool fail_fast_enabled =
+#ifndef NDEBUG
+                true;
+#else
+                false;
+#endif
+
+        array_1d<uint8_t> make_demo_image() {
+            constexpr index_t numPixels = 144;
+            uint8_t raw[numPixels] = {
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+                    2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+                    6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+                    7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1};
+
+            auto image = array_1d<uint8_t>::from_shape({numPixels});
+            for (index_t i = 0; i < numPixels; ++i) {
+                image(i) = raw[i];
+            }
+            return image;
+        }
+
+
+        template<typename range_t>
+        std::vector<index_t> collect_range(const range_t &range) {
+            // Materializes a child range to compare order-sensitive expectations.
+            std::vector<index_t> out;
+            for (auto v: range) {
+                out.push_back(v);
+            }
+            return out;
+        }
+
+        template<typename range_t>
+        std::vector<index_t> collect_nodes(const range_t &range) {
+            // Materializes generic node ranges used by traversal APIs after mutations.
+            std::vector<index_t> out;
+            for (auto v: range) {
+                out.push_back(v);
+            }
+            return out;
+        }
+
+        template<typename tree_t>
+        std::vector<index_t> collect_proper_parts(const tree_t &tree, index_t nodeId) {
+            // Materializes proper parts to compare exact node ownership after mutations.
+            std::vector<index_t> out;
+            for (auto p: tree.getProperParts(nodeId)) {
+                out.push_back(p);
+            }
+            return out;
+        }
+
+        template<typename tree_t>
+        bool has_unreachable_alive_nodes(const tree_t &tree) {
+            // Detects alive internal nodes that are no longer reachable from the current root.
+            std::vector<bool> reachable((size_t) tree.getGlobalIdSpaceSize(), false);
+            if (tree.getRoot() != invalid_index && tree.isAlive(tree.getRoot())) {
+                for (auto nodeId: tree.getNodeSubtree(tree.getRoot())) {
+                    reachable[(size_t) nodeId] = true;
+                }
+            }
+
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (tree.isAlive(nodeId) && !reachable[(size_t) nodeId]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        template<typename tree_t>
+        void require_tree_consistency(const tree_t &tree) {
+            // Checks global invariants: root reachability, parent/child symmetry, and proper-part partition.
+            REQUIRE(tree.getRoot() != invalid_index);
+            REQUIRE(tree.isAlive(tree.getRoot()));
+            REQUIRE(tree.getNodeParent(tree.getRoot()) == tree.getRoot());
+            REQUIRE(!has_unreachable_alive_nodes(tree));
+
+            index_t totalProperParts = 0;
+            std::vector<bool> seenProperParts((size_t) tree.getNumTotalProperParts(), false);
+            for (auto nodeId: tree.getAliveNodeIds()) {
+                if (!tree.isAlive(nodeId)) {
+                    continue;
+                }
+
+                index_t countedChildren = 0;
+                for (auto childId: tree.getChildren(nodeId)) {
+                    REQUIRE(tree.isAlive(childId));
+                    REQUIRE(tree.getNodeParent(childId) == nodeId);
+                    REQUIRE(tree.hasChild(nodeId, childId));
+                    countedChildren++;
+                }
+                REQUIRE(countedChildren == tree.getNumChildren(nodeId));
+
+                index_t countedProperParts = 0;
+                for (auto p: tree.getProperParts(nodeId)) {
+                    REQUIRE(tree.isProperPart(p));
+                    REQUIRE(tree.getSmallestComponent(p) == nodeId);
+                    REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(p)) == tree.getNodeAltitude(nodeId));
+                    REQUIRE(!seenProperParts[(size_t) p]);
+                    seenProperParts[(size_t) p] = true;
+                    countedProperParts++;
+                }
+                REQUIRE(countedProperParts == tree.getNumProperParts(nodeId));
+                totalProperParts += countedProperParts;
+            }
+
+            REQUIRE(totalProperParts == tree.getNumTotalProperParts());
+            REQUIRE(std::all_of(seenProperParts.begin(), seenProperParts.end(), [](bool v) { return v; }));
+        }
+
+    } // namespace
+
+    TEST_CASE("dynamic component tree initial maxtree matches expected structural facts", "[dynamic_component_tree]") {
+        // The demo image should build the reference maxtree documented in the file header.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+    
+            REQUIRE(tree.getNumTotalProperParts() == 144);
+            REQUIRE(tree.getGlobalIdSpaceSize() == 159);
+            REQUIRE(tree.getNumNodes() == 15);
+            REQUIRE(tree.getRoot() == 158);
+            REQUIRE(tree.getNodeAltitude(tree.getRoot()) == 1);
+            REQUIRE(tree.getSmallestComponent(32) == 152);
+            REQUIRE(tree.getSmallestComponent(44) == 150);
+            REQUIRE(tree.getSmallestComponent(109) == 155);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(157)), std::vector<index_t>{152, 155, 156}));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{151, 153}));
+            REQUIRE(vectorSame(collect_proper_parts(tree, 152), std::vector<index_t>{32, 56}));
+            REQUIRE(vectorSame(collect_proper_parts(tree, 150), std::vector<index_t>{44}));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree detach attach move and removeChild preserve topology contracts", "[dynamic_component_tree]") {
+        // Primitive topology operations must keep parent links and sibling order coherent.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            tree.detachNode(151);
+            REQUIRE(tree.getNodeParent(151) == 151);
+            REQUIRE(!tree.hasChild(156, 151));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{153}));
+    
+            tree.attachNode(155, 151);
+            REQUIRE(tree.getNodeParent(151) == 155);
+            REQUIRE(tree.hasChild(155, 151));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(155)), std::vector<index_t>{154, 151}));
+    
+            tree.moveNode(153, 155);
+            REQUIRE(tree.getNodeParent(153) == 155);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(155)), std::vector<index_t>{154, 151, 153}));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{}));
+    
+            tree.removeChild(155, 151, false);
+            REQUIRE(tree.getNodeParent(151) == 151);
+            REQUIRE(!tree.hasChild(155, 151));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(155)), std::vector<index_t>{154, 153}));
+    
+            tree.attachNode(156, 151);
+            REQUIRE(tree.getNodeParent(151) == 156);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{151}));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree moveProperPart keeps both mappings consistent", "[dynamic_component_tree]") {
+        // Moving one proper part must update both the pixel owner and the node proper-part lists.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t sourceNode = tree.getSmallestComponent(32); //nodeId=152
+            const index_t targetNode = tree.getSmallestComponent(44); //nodeId=150
+    
+            REQUIRE(sourceNode != invalid_index);
+            REQUIRE(targetNode != invalid_index);
+            REQUIRE(sourceNode != targetNode);
+            REQUIRE(tree.getNumProperParts(sourceNode) == 2);
+            REQUIRE(tree.getNumProperParts(targetNode) == 1);
+            REQUIRE(tree.getSmallestComponent(32) == sourceNode);
+    
+            tree.moveProperPart(targetNode, sourceNode, 32);
+    
+            REQUIRE(tree.getSmallestComponent(32) == targetNode);
+            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(32)) == tree.getNodeAltitude(targetNode));
+            REQUIRE(tree.getNumProperParts(sourceNode) == 1);
+            REQUIRE(tree.getNumProperParts(targetNode) == 2);
+            REQUIRE(vectorSame(collect_proper_parts(tree, sourceNode), std::vector<index_t>{56}));
+            REQUIRE(vectorSame(collect_proper_parts(tree, targetNode), std::vector<index_t>{44, 32}));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree moveProperParts transfers all direct proper parts at once", "[dynamic_component_tree]") {
+        // Moving all proper parts must preserve the global partition and empty the source node.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t sourceNode = 152;
+            const index_t targetNode = 150;
+    
+            tree.moveProperParts(targetNode, sourceNode);
+    
+            REQUIRE(tree.getNumProperParts(sourceNode) == 0);
+            REQUIRE(tree.getNumProperParts(targetNode) == 3);
+            REQUIRE(vectorSame(collect_proper_parts(tree, targetNode), std::vector<index_t>{44, 32, 56}));
+            REQUIRE(tree.getSmallestComponent(32) == targetNode);
+            REQUIRE(tree.getSmallestComponent(56) == targetNode);
+            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(32)) == tree.getNodeAltitude(targetNode));
+            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(56)) == tree.getNodeAltitude(targetNode));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree moveChildren preserves order and parent mapping", "[dynamic_component_tree]") {
+        // Moving a whole child list must preserve sibling order and redirect every parent link.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t sourceNode = 156;
+            const index_t targetNode = 155;
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(sourceNode)), std::vector<index_t>{151, 153}));
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(targetNode)), std::vector<index_t>{154}));
+    
+            tree.moveChildren(targetNode, sourceNode);
+    
+            REQUIRE(tree.getNumChildren(sourceNode) == 0);
+            REQUIRE(tree.getNumChildren(targetNode) == 3);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(targetNode)), std::vector<index_t>{154, 151, 153}));
+            REQUIRE(tree.getNodeParent(151) == targetNode);
+            REQUIRE(tree.getNodeParent(153) == targetNode);
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree traversal ranges follow the mutated topology", "[dynamic_component_tree]") {
+        // Subtree, descendants, path-to-root and post-order traversals must reflect topology updates.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            tree.moveChildren(155, 156);
+    
+            REQUIRE(vectorEqual(collect_nodes(tree.getChildren(155)), std::vector<index_t>{154, 151, 153}));
+            REQUIRE(vectorEqual(collect_nodes(tree.getNodeSubtree(155)), std::vector<index_t>{155, 154, 148, 147, 144, 151, 149, 153, 145, 146}));
+            REQUIRE(vectorEqual(collect_nodes(tree.getDescendants(155)), std::vector<index_t>{154, 148, 147, 144, 151, 149, 153, 145, 146}));
+            REQUIRE(vectorEqual(collect_nodes(tree.getPathToRootNodes(149)), std::vector<index_t>{149, 151, 155, 157, 158}));
+            REQUIRE(vectorEqual(collect_nodes(tree.getPostOrderNodes(155)), std::vector<index_t>{144, 147, 148, 154, 149, 151, 145, 146, 153, 155}));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree mergeNodeIntoParent promotes children and proper parts", "[dynamic_component_tree]") {
+        // Merging an internal node into its parent must preserve child order and release the merged node.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t mergedNode = 151;
+            const index_t parentNode = tree.getNodeParent(mergedNode);
+            const index_t oldNumNodes = tree.getNumNodes();
+            const index_t oldParentProperParts = tree.getNumProperParts(parentNode);
+    
+            tree.mergeNodeIntoParent(mergedNode);
+    
+            REQUIRE(!tree.isAlive(mergedNode));
+            REQUIRE(tree.getNumNodes() == oldNumNodes - 1);
+            REQUIRE(tree.getNumProperParts(parentNode) == oldParentProperParts + 12);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{153, 149}));
+            REQUIRE(tree.getNodeParent(149) == parentNode);
+            REQUIRE(tree.getSmallestComponent(13) == parentNode);
+            REQUIRE(tree.getSmallestComponent(63) == parentNode);
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree pruneNode removes subtree and moves proper parts to parent", "[dynamic_component_tree]") {
+        // Pruning removes all internal nodes in the subtree and transfers their proper parts to the parent.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t prunedNode = 151;
+            const index_t parentNode = tree.getNodeParent(prunedNode);
+            const index_t oldNumNodes = tree.getNumNodes();
+            const index_t oldParentProperParts = tree.getNumProperParts(parentNode);
+    
+            tree.pruneNode(prunedNode);
+    
+            REQUIRE(!tree.isAlive(prunedNode));
+            REQUIRE(tree.getNumNodes() == oldNumNodes - 2);
+            REQUIRE(tree.getNumProperParts(parentNode) == oldParentProperParts + 15);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{153}));
+            REQUIRE(tree.getSmallestComponent(13) == parentNode);
+            REQUIRE(tree.getSmallestComponent(44) == 150);
+            REQUIRE(tree.getSmallestComponent(26) == parentNode);
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree setRoot only changes the designated root node", "[dynamic_component_tree]") {
+        // setRoot promotes one node and leaves the previous root detached from the rooted hierarchy.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+    
+            const index_t oldRoot = tree.getRoot();
+            const index_t newRoot = 157;
+    
+            tree.setRoot(newRoot);
+    
+            REQUIRE(tree.getRoot() == newRoot);
+            REQUIRE(tree.getNodeParent(newRoot) == newRoot);
+            REQUIRE(tree.getNodeParent(oldRoot) == oldRoot);
+            REQUIRE(!tree.hasChild(oldRoot, newRoot));
+            REQUIRE(has_unreachable_alive_nodes(tree));
+            REQUIRE(collect_nodes(tree.getNodeSubtree(newRoot)).front() == newRoot);
+            REQUIRE(tree.getNumNodes() == 15);
+        }
+    }
+
+    TEST_CASE("dynamic component tree releaseNode and allocateNode reuse detached leaf slots", "[dynamic_component_tree]") {
+        // Releasing a detached empty node must make its slot immediately reusable by allocateNode.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t reusableNode = 150;
+            const index_t parentNode = tree.getNodeParent(reusableNode);
+            const index_t siblingOwner = 152;
+            const index_t oldFreeIds = tree.getNumFreeNodeSlots();
+    
+            tree.moveProperPart(siblingOwner, reusableNode, 44);
+            tree.removeChild(parentNode, reusableNode, false);
+            tree.releaseNode(reusableNode);
+    
+            REQUIRE(!tree.isAlive(reusableNode));
+            REQUIRE(tree.getNumFreeNodeSlots() == oldFreeIds + 1);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{}));
+            REQUIRE(vectorSame(collect_proper_parts(tree, siblingOwner), std::vector<index_t>{32, 56, 44}));
+    
+            const index_t newNode = tree.allocateNode(9);
+            REQUIRE(newNode == reusableNode);
+            REQUIRE(tree.isAlive(newNode));
+            REQUIRE(tree.getNodeParent(newNode) == newNode);
+            REQUIRE(tree.getNodeAltitude(newNode) == 9);
+            REQUIRE(tree.getNumChildren(newNode) == 0);
+            REQUIRE(tree.getNumProperParts(newNode) == 0);
+            tree.attachNode(parentNode, newNode);
+            REQUIRE(tree.getNodeParent(newNode) == parentNode);
+            REQUIRE(tree.hasChild(parentNode, newNode));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree removeChild with releaseNode removes empty leaf child", "[dynamic_component_tree]") {
+        // removeChild(..., true) must detach and release a leaf internal node with no proper parts.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+            require_tree_consistency(tree);
+    
+            const index_t parentNode = 152;
+            const index_t releasedNode = 150;
+            const index_t oldNumNodes = tree.getNumNodes();
+            const index_t oldFreeIds = tree.getNumFreeNodeSlots();
+    
+            tree.moveProperPart(parentNode, releasedNode, 44);
+            tree.removeChild(parentNode, releasedNode, true);
+    
+            REQUIRE(!tree.isAlive(releasedNode));
+            REQUIRE(tree.getNumNodes() == oldNumNodes - 1);
+            REQUIRE(tree.getNumFreeNodeSlots() == oldFreeIds + 1);
+            REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{}));
+            REQUIRE(vectorSame(collect_proper_parts(tree, parentNode), std::vector<index_t>{32, 56, 44}));
+            require_tree_consistency(tree);
+        }
+    }
+
+    TEST_CASE("dynamic component tree fail-fast invalidates alive-node range on node-set changes", "[dynamic_component_tree]") {
+        // Alive-node iteration must fail fast if the alive node set changes after the range is created.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+    
+            auto nodes = tree.getAliveNodeIds();
+            auto it = nodes.begin();
+            REQUIRE(*it == 144);
+
+            tree.moveProperPart(152, 150, 44);
+            tree.detachNode(150);
+            tree.releaseNode(150);
+
+            if constexpr (fail_fast_enabled) {
+                REQUIRE_THROWS_AS(*it, std::runtime_error);
+            } else {
+                (void) *it;
+            }
+        }
+    }
+
+    TEST_CASE("dynamic component tree fail-fast invalidates topology ranges on structural changes", "[dynamic_component_tree]") {
+        // Topology-based traversals must fail fast after a structural mutation.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+    
+            auto children = tree.getChildren(156);
+            auto childIt = children.begin();
+            REQUIRE(*childIt == 151);
+            tree.moveNode(153, 155);
+            if constexpr (fail_fast_enabled) {
+                REQUIRE_THROWS_AS(*childIt, std::runtime_error);
+            } else {
+                (void) *childIt;
+            }
+    
+            auto subtree = tree.getNodeSubtree(157);
+            auto subtreeIt = subtree.begin();
+            REQUIRE(*subtreeIt == 157);
+            tree.detachNode(152);
+            if constexpr (fail_fast_enabled) {
+                REQUIRE_THROWS_AS(++subtreeIt, std::runtime_error);
+            } else {
+                ++subtreeIt;
+            }
+    
+            auto postOrder = tree.getPostOrderNodes(157);
+            auto postIt = postOrder.begin();
+            REQUIRE(*postIt == 144);
+            tree.attachNode(157, 152);
+            if constexpr (fail_fast_enabled) {
+                REQUIRE_THROWS_AS(*postIt, std::runtime_error);
+            } else {
+                (void) *postIt;
+            }
+        }
+    }
+
+    TEST_CASE("dynamic component tree fail-fast invalidates proper-part ranges on ownership changes", "[dynamic_component_tree]") {
+        // Proper-part iteration must fail fast after a proper-part ownership mutation.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            tree_t tree(graph, image, true);
+
+            auto parts = tree.getProperParts(152);
+            auto partIt = parts.begin();
+            REQUIRE(tree.getSmallestComponent(*partIt) == 152);
+
+            tree.moveProperPart(150, 152, 32);
+    
+            if constexpr (fail_fast_enabled) {
+                REQUIRE_THROWS_AS(*partIt, std::runtime_error);
+            } else {
+                (void) *partIt;
+            }
+        }
+    }
+} // namespace dynamic_component_tree

--- a/test/cpp/hierarchy/test_dynamic_component_tree.cpp
+++ b/test/cpp/hierarchy/test_dynamic_component_tree.cpp
@@ -9,7 +9,10 @@
 ****************************************************************************/
 
 #include "../test_utils.hpp"
+#include "higra/algo/tree.hpp"
 #include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/hierarchy/common.hpp"
+#include "higra/hierarchy/component_tree.hpp"
 #include "higra/image/graph_image.hpp"
 
 
@@ -61,7 +64,7 @@ namespace dynamic_component_tree {
     namespace {
 
 
-        using tree_t = DynamicComponentTree<uint8_t>;
+        using tree_t = detail::hierarchy::DynamicComponentTree;
 
         constexpr bool fail_fast_enabled =
 #ifndef NDEBUG
@@ -93,6 +96,26 @@ namespace dynamic_component_tree {
             return image;
         }
 
+
+
+        template<typename graph_t>
+        tree_t make_component_tree_from_image(const graph_t &graph, const array_1d<uint8_t> &image, bool isMaxTree) {
+            const auto staticTree = isMaxTree ? component_tree_max_tree(graph, image) : component_tree_min_tree(graph, image);
+            tree_t tree;
+            tree.reset(staticTree.tree);
+            return tree;
+        }
+
+        template<typename graph_t>
+        std::pair<tree_t, std::vector<uint8_t>> make_component_tree_with_altitude(const graph_t &graph,
+                                                                                  const array_1d<uint8_t> &image,
+                                                                                  bool isMaxTree) {
+            // Builds the static component tree first, then mirrors its topology and altitudes into the dynamic setup.
+            const auto staticTree = isMaxTree ? component_tree_max_tree(graph, image) : component_tree_min_tree(graph, image);
+            tree_t tree;
+            tree.reset(staticTree.tree);
+            return {std::move(tree), std::vector<uint8_t>(staticTree.altitudes.begin(), staticTree.altitudes.end())};
+        }
 
         template<typename range_t>
         std::vector<index_t> collect_range(const range_t &range) {
@@ -142,8 +165,8 @@ namespace dynamic_component_tree {
             return false;
         }
 
-        template<typename tree_t>
-        void require_tree_consistency(const tree_t &tree) {
+        template<typename tree_t, typename altitude_t>
+        void require_tree_consistency(const tree_t &tree, const std::vector<altitude_t> &altitude) {
             // Checks global invariants: root reachability, parent/child symmetry, and proper-part partition.
             REQUIRE(tree.getRoot() != invalid_index);
             REQUIRE(tree.isAlive(tree.getRoot()));
@@ -170,7 +193,7 @@ namespace dynamic_component_tree {
                 for (auto p: tree.getProperParts(nodeId)) {
                     REQUIRE(tree.isProperPart(p));
                     REQUIRE(tree.getSmallestComponent(p) == nodeId);
-                    REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(p)) == tree.getNodeAltitude(nodeId));
+                    REQUIRE(altitude[(size_t) tree.getSmallestComponent(p)] == altitude[(size_t) nodeId]);
                     REQUIRE(!seenProperParts[(size_t) p]);
                     seenProperParts[(size_t) p] = true;
                     countedProperParts++;
@@ -190,13 +213,13 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
     
             REQUIRE(tree.getNumTotalProperParts() == 144);
             REQUIRE(tree.getGlobalIdSpaceSize() == 159);
             REQUIRE(tree.getNumNodes() == 15);
             REQUIRE(tree.getRoot() == 158);
-            REQUIRE(tree.getNodeAltitude(tree.getRoot()) == 1);
+            REQUIRE(altitude[(size_t) tree.getRoot()] == 1);
             REQUIRE(tree.getSmallestComponent(32) == 152);
             REQUIRE(tree.getSmallestComponent(44) == 150);
             REQUIRE(tree.getSmallestComponent(109) == 155);
@@ -204,7 +227,7 @@ namespace dynamic_component_tree {
             REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{151, 153}));
             REQUIRE(vectorSame(collect_proper_parts(tree, 152), std::vector<index_t>{32, 56}));
             REQUIRE(vectorSame(collect_proper_parts(tree, 150), std::vector<index_t>{44}));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -213,8 +236,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             tree.detachNode(151);
             REQUIRE(tree.getNodeParent(151) == 151);
@@ -239,7 +262,7 @@ namespace dynamic_component_tree {
             tree.attachNode(156, 151);
             REQUIRE(tree.getNodeParent(151) == 156);
             REQUIRE(vectorEqual(collect_range(tree.getChildren(156)), std::vector<index_t>{151}));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -248,8 +271,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t sourceNode = tree.getSmallestComponent(32); //nodeId=152
             const index_t targetNode = tree.getSmallestComponent(44); //nodeId=150
@@ -264,12 +287,12 @@ namespace dynamic_component_tree {
             tree.moveProperPart(targetNode, sourceNode, 32);
     
             REQUIRE(tree.getSmallestComponent(32) == targetNode);
-            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(32)) == tree.getNodeAltitude(targetNode));
+            REQUIRE(altitude[(size_t) tree.getSmallestComponent(32)] == altitude[(size_t) targetNode]);
             REQUIRE(tree.getNumProperParts(sourceNode) == 1);
             REQUIRE(tree.getNumProperParts(targetNode) == 2);
             REQUIRE(vectorSame(collect_proper_parts(tree, sourceNode), std::vector<index_t>{56}));
             REQUIRE(vectorSame(collect_proper_parts(tree, targetNode), std::vector<index_t>{44, 32}));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -278,8 +301,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t sourceNode = 152;
             const index_t targetNode = 150;
@@ -291,9 +314,9 @@ namespace dynamic_component_tree {
             REQUIRE(vectorSame(collect_proper_parts(tree, targetNode), std::vector<index_t>{44, 32, 56}));
             REQUIRE(tree.getSmallestComponent(32) == targetNode);
             REQUIRE(tree.getSmallestComponent(56) == targetNode);
-            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(32)) == tree.getNodeAltitude(targetNode));
-            REQUIRE(tree.getNodeAltitude(tree.getSmallestComponent(56)) == tree.getNodeAltitude(targetNode));
-            require_tree_consistency(tree);
+            REQUIRE(altitude[(size_t) tree.getSmallestComponent(32)] == altitude[(size_t) targetNode]);
+            REQUIRE(altitude[(size_t) tree.getSmallestComponent(56)] == altitude[(size_t) targetNode]);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -302,8 +325,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t sourceNode = 156;
             const index_t targetNode = 155;
@@ -317,7 +340,50 @@ namespace dynamic_component_tree {
             REQUIRE(vectorEqual(collect_range(tree.getChildren(targetNode)), std::vector<index_t>{154, 151, 153}));
             REQUIRE(tree.getNodeParent(151) == targetNode);
             REQUIRE(tree.getNodeParent(153) == targetNode);
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
+        }
+    }
+
+    TEST_CASE("dynamic component tree keeps surviving node ids stable under pure topology updates", "[dynamic_component_tree]") {
+        // Detach/attach/move operations must not renumber or replace surviving internal nodes.
+        auto graph = get_4_adjacency_implicit_graph({12, 12});
+        auto image = make_demo_image();
+        {
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
+
+            const std::vector<index_t> trackedNodes{148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158};
+            std::vector<std::vector<index_t>> trackedProperParts;
+            trackedProperParts.reserve(trackedNodes.size());
+            for (auto nodeId: trackedNodes) {
+                REQUIRE(tree.isAlive(nodeId));
+                trackedProperParts.push_back(collect_proper_parts(tree, nodeId));
+            }
+
+            tree.detachNode(151);
+            tree.attachNode(155, 151);
+            tree.moveNode(153, 155);
+            tree.moveChildren(155, 156);
+
+            for (size_t i = 0; i < trackedNodes.size(); ++i) {
+                const auto nodeId = trackedNodes[i];
+                REQUIRE(tree.isAlive(nodeId));
+                REQUIRE(vectorSame(collect_proper_parts(tree, nodeId), trackedProperParts[i]));
+                for (auto p: trackedProperParts[i]) {
+                    REQUIRE(tree.getSmallestComponent(p) == nodeId);
+                }
+            }
+
+            REQUIRE(tree.getRoot() == 158);
+            REQUIRE(tree.getNodeParent(152) == 157);
+            REQUIRE(tree.getNodeParent(155) == 157);
+            REQUIRE(tree.getNodeParent(156) == 157);
+            REQUIRE(tree.getNodeParent(151) == 155);
+            REQUIRE(tree.getNodeParent(153) == 155);
+            REQUIRE(tree.getNodeParent(149) == 151);
+            REQUIRE(tree.getNodeParent(154) == 155);
+            REQUIRE(tree.getNodeParent(148) == 154);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -326,8 +392,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             tree.moveChildren(155, 156);
     
@@ -336,7 +402,7 @@ namespace dynamic_component_tree {
             REQUIRE(vectorEqual(collect_nodes(tree.getDescendants(155)), std::vector<index_t>{154, 148, 147, 144, 151, 149, 153, 145, 146}));
             REQUIRE(vectorEqual(collect_nodes(tree.getPathToRootNodes(149)), std::vector<index_t>{149, 151, 155, 157, 158}));
             REQUIRE(vectorEqual(collect_nodes(tree.getPostOrderNodes(155)), std::vector<index_t>{144, 147, 148, 154, 149, 151, 145, 146, 153, 155}));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -345,8 +411,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t mergedNode = 151;
             const index_t parentNode = tree.getNodeParent(mergedNode);
@@ -362,7 +428,7 @@ namespace dynamic_component_tree {
             REQUIRE(tree.getNodeParent(149) == parentNode);
             REQUIRE(tree.getSmallestComponent(13) == parentNode);
             REQUIRE(tree.getSmallestComponent(63) == parentNode);
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -371,8 +437,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t prunedNode = 151;
             const index_t parentNode = tree.getNodeParent(prunedNode);
@@ -388,7 +454,7 @@ namespace dynamic_component_tree {
             REQUIRE(tree.getSmallestComponent(13) == parentNode);
             REQUIRE(tree.getSmallestComponent(44) == 150);
             REQUIRE(tree.getSmallestComponent(26) == parentNode);
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -397,7 +463,7 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
+            tree_t tree = make_component_tree_from_image(graph, image, true);
     
             const index_t oldRoot = tree.getRoot();
             const index_t newRoot = 157;
@@ -419,8 +485,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t reusableNode = 150;
             const index_t parentNode = tree.getNodeParent(reusableNode);
@@ -436,17 +502,16 @@ namespace dynamic_component_tree {
             REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{}));
             REQUIRE(vectorSame(collect_proper_parts(tree, siblingOwner), std::vector<index_t>{32, 56, 44}));
     
-            const index_t newNode = tree.allocateNode(9);
+            const index_t newNode = tree.allocateNode();
             REQUIRE(newNode == reusableNode);
             REQUIRE(tree.isAlive(newNode));
             REQUIRE(tree.getNodeParent(newNode) == newNode);
-            REQUIRE(tree.getNodeAltitude(newNode) == 9);
             REQUIRE(tree.getNumChildren(newNode) == 0);
             REQUIRE(tree.getNumProperParts(newNode) == 0);
             tree.attachNode(parentNode, newNode);
             REQUIRE(tree.getNodeParent(newNode) == parentNode);
             REQUIRE(tree.hasChild(parentNode, newNode));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -455,8 +520,8 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
-            require_tree_consistency(tree);
+            auto [tree, altitude] = make_component_tree_with_altitude(graph, image, true);
+            require_tree_consistency(tree, altitude);
     
             const index_t parentNode = 152;
             const index_t releasedNode = 150;
@@ -471,7 +536,7 @@ namespace dynamic_component_tree {
             REQUIRE(tree.getNumFreeNodeSlots() == oldFreeIds + 1);
             REQUIRE(vectorEqual(collect_range(tree.getChildren(parentNode)), std::vector<index_t>{}));
             REQUIRE(vectorSame(collect_proper_parts(tree, parentNode), std::vector<index_t>{32, 56, 44}));
-            require_tree_consistency(tree);
+            require_tree_consistency(tree, altitude);
         }
     }
 
@@ -480,7 +545,7 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
+            tree_t tree = make_component_tree_from_image(graph, image, true);
     
             auto nodes = tree.getAliveNodeIds();
             auto it = nodes.begin();
@@ -503,7 +568,7 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
+            tree_t tree = make_component_tree_from_image(graph, image, true);
     
             auto children = tree.getChildren(156);
             auto childIt = children.begin();
@@ -542,7 +607,7 @@ namespace dynamic_component_tree {
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
-            tree_t tree(graph, image, true);
+            tree_t tree = make_component_tree_from_image(graph, image, true);
 
             auto parts = tree.getProperParts(152);
             auto partIt = parts.begin();

--- a/test/cpp/hierarchy/test_dynamic_component_tree.cpp
+++ b/test/cpp/hierarchy/test_dynamic_component_tree.cpp
@@ -17,7 +17,7 @@
 
 
 /*
-* Reference dynamic maxtree:
+* Reference dynamic max-tree:
 *      
 *               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
 *               2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
@@ -32,7 +32,7 @@
 *               7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
 *               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1
 * 
-* Dynamic maxtree:
+* Dynamic max-tree:
 * └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
 *    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143], ProperPartCount: 22
 *    └──ID: 157, Parent: 158, Altitude: 2, NumChildren: 3,
@@ -209,7 +209,7 @@ namespace dynamic_component_tree {
     } // namespace
 
     TEST_CASE("dynamic component tree initial maxtree matches expected structural facts", "[dynamic_component_tree]") {
-        // The demo image should build the reference maxtree documented in the file header.
+        // The demo image should build the reference max-tree documented in the file header.
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {
@@ -267,7 +267,7 @@ namespace dynamic_component_tree {
     }
 
     TEST_CASE("dynamic component tree moveProperPart keeps both mappings consistent", "[dynamic_component_tree]") {
-        // Moving one proper part must update both the pixel owner and the node proper-part lists.
+        // Moving one proper part must update both its owner and the node proper-part lists.
         auto graph = get_4_adjacency_implicit_graph({12, 12});
         auto image = make_demo_image();
         {

--- a/test/cpp/hierarchy/test_dynamic_component_tree_attribute_computers.cpp
+++ b/test/cpp/hierarchy/test_dynamic_component_tree_attribute_computers.cpp
@@ -1,0 +1,202 @@
+/***************************************************************************
+* Copyright ESIEE Paris (2018)                                             *
+*                                                                          *
+* Contributor(s) : Wonder Alexandre Luz Alves                              *
+*                                                                          *
+* Distributed under the terms of the CECILL-B License.                     *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "../test_utils.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree.hpp"
+#include "higra/detail/hierarchy/dynamic_component_tree_attribute_computers.hpp"
+#include "higra/hierarchy/component_tree.hpp"
+#include "higra/image/graph_image.hpp"
+
+/*
+* Reference dynamic maxtree:
+*      
+*               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+*               2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+*               2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+*    image  =   2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+*               3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+*               2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+*               6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+*               7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+*               7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+*               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1
+* 
+* Dynamic maxtree:
+* └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
+*    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143], ProperPartCount: 22
+*    └──ID: 157, Parent: 158, Altitude: 2, NumChildren: 3,
+*       ProperParts: [0, 1, 2, 3, 4, 5, 12, 19, 20, 21, 24, 31, 33, 36, 43, 45, 48, 55, 57, 60, 67, 68, 69, 84, 85, 86, 87, 88, 89, 101, 113, 125, 132, 133, 134, 135, 136, 137], ProperPartCount: 38
+*       ├──ID: 152, Parent: 157, Altitude: 5, NumChildren: 1, ProperParts: [32, 56], ProperPartCount: 2
+*       │  └──ID: 150, Parent: 152, Altitude: 6, NumChildren: 0, ProperParts: [44], ProperPartCount: 1
+*       ├──ID: 155, Parent: 157, Altitude: 3, NumChildren: 1, ProperParts: [109], ProperPartCount: 1
+*       │  └──ID: 154, Parent: 155, Altitude: 4, NumChildren: 1, ProperParts: [111], ProperPartCount: 1
+*       │     └──ID: 148, Parent: 154, Altitude: 6, NumChildren: 1,
+*       │        ProperParts: [96, 97, 98, 99, 100, 110, 112, 122, 123, 124], ProperPartCount: 10
+*       │        └──ID: 147, Parent: 148, Altitude: 7, NumChildren: 1, ProperParts: [108, 120], ProperPartCount: 2
+*       │           └──ID: 144, Parent: 147, Altitude: 8, NumChildren: 0, ProperParts: [121], ProperPartCount: 1
+*       └──ID: 156, Parent: 157, Altitude: 3, NumChildren: 2,
+*          ProperParts: [16, 17, 18, 22, 28, 29, 30, 34, 40, 41, 42, 46, 52, 53, 54, 58, 64, 65, 66, 70, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 90, 91, 92, 93, 94], ProperPartCount: 36
+*          ├──ID: 151, Parent: 156, Altitude: 5, NumChildren: 1,
+*          │  ProperParts: [13, 14, 15, 25, 27, 37, 39, 49, 51, 61, 62, 63], ProperPartCount: 12
+*          │  └──ID: 149, Parent: 151, Altitude: 6, NumChildren: 0, ProperParts: [26, 38, 50], ProperPartCount: 3
+*          └──ID: 153, Parent: 156, Altitude: 4, NumChildren: 2,
+*             ProperParts: [102, 103, 104, 105, 106, 114, 116, 118, 126, 127, 128, 129, 130], ProperPartCount: 13
+*             ├──ID: 145, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [117], ProperPartCount: 1
+*             └──ID: 146, Parent: 153, Altitude: 8, NumChildren: 0, ProperParts: [115], ProperPartCount: 1
+*/
+
+using namespace hg;
+
+namespace dynamic_component_tree_attribute_computers {
+
+    namespace {
+
+        array_1d<uint8_t> make_demo_image() {
+            constexpr index_t numPixels = 144;
+            uint8_t raw[numPixels] = {
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 6, 2, 3, 1,
+                    2, 5, 6, 5, 3, 3, 3, 2, 5, 2, 3, 1,
+                    2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
+                    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1,
+                    2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 1,
+                    6, 6, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    7, 3, 6, 4, 6, 2, 4, 8, 4, 8, 4, 1,
+                    7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
+                    2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1};
+
+            auto image = array_1d<uint8_t>::from_shape({numPixels});
+            for (index_t i = 0; i < numPixels; ++i) {
+                image(i) = raw[i];
+            }
+            return image;
+        }
+
+        template<typename value_t>
+        void require_equal_buffers(const std::vector<value_t> &lhs, const std::vector<value_t> &rhs) {
+            // Bounding-box attributes are scalar doubles in the current tests, so Approx keeps the helper
+            // usable for width/height and diagonal-length checks with the same code path.
+            REQUIRE(lhs.size() == rhs.size());
+            for (size_t i = 0; i < lhs.size(); ++i) {
+                REQUIRE(lhs[i] == Approx(rhs[i]));
+            }
+        }
+
+    } // namespace
+
+    TEST_CASE("dynamic component tree scalar attribute computers") {
+        // Full bottom-up recomputation must recover the expected area and bounding-box measures on the
+        // untouched reference maxtree.
+        embedding_grid_2d embedding({12, 12});
+        auto graph = get_4_adjacency_graph(embedding);
+        auto image = make_demo_image();
+        const auto staticTree = component_tree_max_tree(graph, image);
+        detail::hierarchy::DynamicComponentTree maxtree;
+        maxtree.reset(staticTree.tree);
+
+        detail::hierarchy::DynamicComponentTreeAreaAttributeComputer<> areaComputer;
+        std::vector<double> area;
+        areaComputer.computeAttribute(maxtree, area);
+
+        REQUIRE(area[(size_t) maxtree.getRoot()] == 144.0);
+        REQUIRE(area[(size_t) 152] == 3.0);
+        REQUIRE(area[(size_t) 150] == 1.0);
+
+        auto pixelToPoint = [](index_t pixelId) {
+            return std::pair<index_t, index_t>{pixelId / 12, pixelId % 12};
+        };
+
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                diagonalComputer(pixelToPoint, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::diagonal_length);
+        std::vector<double> diagonal;
+        diagonalComputer.computeAttribute(maxtree, diagonal);
+
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                widthComputer(pixelToPoint, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::width);
+        std::vector<double> width;
+        widthComputer.computeAttribute(maxtree, width);
+
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                heightComputer(pixelToPoint, detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure::height);
+        std::vector<double> height;
+        heightComputer.computeAttribute(maxtree, height);
+
+        REQUIRE(width[(size_t) maxtree.getRoot()] == 12.0);
+        REQUIRE(height[(size_t) maxtree.getRoot()] == 12.0);
+        REQUIRE(diagonal[(size_t) maxtree.getRoot()] == Approx(std::sqrt(288.0)));
+
+        REQUIRE(width[(size_t) 152] == 1.0);
+        REQUIRE(height[(size_t) 152] == 3.0);
+        REQUIRE(diagonal[(size_t) 152] == Approx(std::sqrt(10.0)));
+    }
+
+    TEST_CASE("dynamic component tree bounding-box computer matches full recomputation after a local edit") {
+        // computeAttributeOnNode only refreshes one node from its current children and proper parts. After a
+        // local edit, callers must therefore recompute the affected path bottom-up. This test checks that this
+        // incremental refresh strategy matches a full recomputation for the bounding-box attribute.
+        embedding_grid_2d embedding({12, 12});
+        auto graph = get_4_adjacency_graph(embedding);
+        auto image = make_demo_image();
+        const auto staticTree = component_tree_max_tree(graph, image);
+        detail::hierarchy::DynamicComponentTree maxtree;
+        maxtree.reset(staticTree.tree);
+
+        auto pixelToPoint = [](index_t pixelId) {
+            return std::pair<index_t, index_t>{pixelId / 12, pixelId % 12};
+        };
+
+        using measure_t = detail::hierarchy::DynamicComponentTreeBoundingBoxMeasure;
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                diagonalComputer(pixelToPoint, measure_t::diagonal_length);
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                widthComputer(pixelToPoint, measure_t::width);
+        detail::hierarchy::DynamicComponentTreeBoundingBoxAttributeComputer<decltype(pixelToPoint)>
+                heightComputer(pixelToPoint, measure_t::height);
+
+        std::vector<double> diagonalIncremental;
+        std::vector<double> widthIncremental;
+        std::vector<double> heightIncremental;
+        diagonalComputer.computeAttribute(maxtree, diagonalIncremental);
+        widthComputer.computeAttribute(maxtree, widthIncremental);
+        heightComputer.computeAttribute(maxtree, heightIncremental);
+
+        // Move one direct proper part from node 152 to its parent 157. This changes the source box, the
+        // target box, and the root box, so the affected path is exactly 152 -> 157 -> 158.
+        maxtree.moveProperPart(157, 152, 32);
+
+        for (const index_t nodeId: std::vector<index_t>{152, 157, 158}) {
+            diagonalComputer.computeAttributeOnNode(maxtree, nodeId, diagonalIncremental);
+            widthComputer.computeAttributeOnNode(maxtree, nodeId, widthIncremental);
+            heightComputer.computeAttributeOnNode(maxtree, nodeId, heightIncremental);
+        }
+
+        std::vector<double> diagonalFull;
+        std::vector<double> widthFull;
+        std::vector<double> heightFull;
+        diagonalComputer.computeAttribute(maxtree, diagonalFull);
+        widthComputer.computeAttribute(maxtree, widthFull);
+        heightComputer.computeAttribute(maxtree, heightFull);
+
+        require_equal_buffers(diagonalIncremental, diagonalFull);
+        require_equal_buffers(widthIncremental, widthFull);
+        require_equal_buffers(heightIncremental, heightFull);
+
+        REQUIRE(widthIncremental[(size_t) 152] == 1.0);
+        REQUIRE(heightIncremental[(size_t) 152] == 2.0);
+        REQUIRE(diagonalIncremental[(size_t) 152] == Approx(std::sqrt(5.0)));
+        REQUIRE(widthIncremental[(size_t) 157] == 11.0);
+        REQUIRE(heightIncremental[(size_t) 157] == 12.0);
+    }
+
+} // namespace dynamic_component_tree_attribute_computers

--- a/test/cpp/hierarchy/test_dynamic_component_tree_attribute_computers.cpp
+++ b/test/cpp/hierarchy/test_dynamic_component_tree_attribute_computers.cpp
@@ -15,7 +15,7 @@
 #include "higra/image/graph_image.hpp"
 
 /*
-* Reference dynamic maxtree:
+* Reference dynamic max-tree:
 *      
 *               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1,
 *               2, 5, 5, 5, 3, 3, 3, 2, 2, 2, 3, 1,
@@ -30,7 +30,7 @@
 *               7, 8, 6, 6, 6, 2, 4, 4, 4, 4, 4, 1,
 *               2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1
 * 
-* Dynamic maxtree:
+* Dynamic max-tree:
 * └──ID: 158, Parent: 158, Altitude: 1, NumChildren: 1,
 *    ProperParts: [6, 7, 8, 9, 10, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119, 131, 138, 139, 140, 141, 142, 143], ProperPartCount: 22
 *    └──ID: 157, Parent: 158, Altitude: 2, NumChildren: 3,
@@ -97,7 +97,7 @@ namespace dynamic_component_tree_attribute_computers {
 
     TEST_CASE("dynamic component tree scalar attribute computers") {
         // Full bottom-up recomputation must recover the expected area and bounding-box measures on the
-        // untouched reference maxtree.
+        // untouched reference max-tree.
         embedding_grid_2d embedding({12, 12});
         auto graph = get_4_adjacency_graph(embedding);
         auto image = make_demo_image();

--- a/test/python/test_hierarchy/CMakeLists.txt
+++ b/test/python/test_hierarchy/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PY_FILES
         test_binary_partition_tree.py
         test_constrained_connectivity_hierarchy.py
         test_component_tree.py
+        test_component_tree_dual_filter.py
         test_hierarchy_core.py
         test_random_hierarchy.py
         test_watershed_hierarchy.py)

--- a/test/python/test_hierarchy/test_component_tree_dual_filter.py
+++ b/test/python/test_hierarchy/test_component_tree_dual_filter.py
@@ -1,0 +1,111 @@
+############################################################################
+# Copyright ESIEE Paris (2018)                                             #
+#                                                                          #
+# Contributor(s) : Wonder Alexandre Luz Alves                              #
+#                                                                          #
+# Distributed under the terms of the CECILL-B License.                     #
+#                                                                          #
+# The full license is in the file LICENSE, distributed with this software. #
+############################################################################
+
+import unittest
+import higra as hg
+import numpy as np
+
+
+def naive_area_casf(graph, image, thresholds):
+    current = image
+    for threshold in thresholds:
+        max_tree, max_altitudes = hg.component_tree_max_tree(graph, current)
+        max_area = hg.attribute_area(max_tree)
+        filtered = hg.reconstruct_leaf_data(max_tree, max_altitudes, max_area <= threshold)
+
+        min_tree, min_altitudes = hg.component_tree_min_tree(graph, filtered)
+        min_area = hg.attribute_area(min_tree)
+        current = hg.reconstruct_leaf_data(min_tree, min_altitudes, min_area <= threshold)
+
+    return current
+
+
+class TestComponentTreeDualFilter(unittest.TestCase):
+
+    def test_connected_alternating_sequential_filter_area(self):
+        graph = hg.get_4_adjacency_implicit_graph((6, 6))
+        image = np.asarray(((-5, 2, 2, 5, 5, 5),
+                            (-4, 2, 2, 6, 5, 4),
+                            (3, 3, 3, 3, 3, 3),
+                            (-2, -2, -2, 9, 7, 6),
+                            (-1, 0, -2, 8, 9, 8),
+                            (-1, -1, -2, 7, 8, 9)), dtype=np.float64)
+        thresholds = [2, 4, 6]
+
+        expected = naive_area_casf(graph, image, thresholds)
+        result = hg.connected_alternating_sequential_filter(graph, image, "area", thresholds)
+
+        self.assertTrue(np.allclose(result, expected))
+
+    def test_connected_alternating_sequential_filter_accepts_enum(self):
+        graph = hg.get_4_adjacency_implicit_graph((4, 4))
+        image = np.asarray(((0, 2, 0, 1),
+                            (2, 5, 2, 1),
+                            (0, 2, 4, 3),
+                            (1, 1, 3, 6)), dtype=np.uint8)
+        thresholds = [1, 2, 3]
+
+        result_str = hg.connected_alternating_sequential_filter(graph, image, "area", thresholds)
+        result_enum = hg.connected_alternating_sequential_filter(graph, image, hg.CasfAttribute.area, thresholds)
+
+        self.assertTrue(np.allclose(result_str, result_enum))
+
+    def test_connected_alternating_sequential_filter_empty_thresholds(self):
+        graph = hg.get_4_adjacency_implicit_graph((3, 4))
+        image = np.asarray(((0, 1, 2, 3),
+                            (4, 5, 6, 7),
+                            (8, 9, 10, 11)), dtype=np.uint8)
+
+        result = hg.connected_alternating_sequential_filter(graph, image, "area", [])
+
+        self.assertTrue(np.allclose(result, image))
+
+    def test_connected_alternating_sequential_filter_preserves_shape(self):
+        graph = hg.get_4_adjacency_implicit_graph((3, 5))
+        image = np.asarray(((0, 1, 2, 3, 4),
+                            (5, 6, 7, 8, 9),
+                            (10, 11, 12, 13, 14)), dtype=np.uint8)
+
+        result = hg.connected_alternating_sequential_filter(graph, image, "area", [1, 2, 3])
+
+        self.assertEqual(result.shape, image.shape)
+
+    def test_connected_alternating_sequential_filter_invalid_attribute(self):
+        graph = hg.get_4_adjacency_implicit_graph((3, 3))
+        image = np.asarray(((0, 1, 2),
+                            (3, 4, 5),
+                            (6, 7, 8)), dtype=np.uint8)
+
+        with self.assertRaises(ValueError):
+            hg.connected_alternating_sequential_filter(graph, image, "invalid_attribute", [1, 2, 3])
+
+    def test_connected_alternating_sequential_filter_bounding_box(self):
+        graph = hg.get_4_adjacency_implicit_graph((5, 6))
+        image = np.asarray(((0, 0, 0, 0, 0, 0),
+                            (0, 5, 5, 0, 3, 0),
+                            (0, 5, 5, 0, 3, 0),
+                            (0, 0, 0, 0, 3, 0),
+                            (0, 0, 0, 0, 0, 0)), dtype=np.uint8)
+
+        result = hg.connected_alternating_sequential_filter(graph, image, "bounding_box_width", [1, 2, 3])
+
+        self.assertEqual(result.shape, image.shape)
+
+    def test_connected_alternating_sequential_filter_bounding_box_requires_embedding(self):
+        graph = hg.UndirectedGraph(4)
+        graph.add_edges((0, 1, 0, 2), (1, 3, 2, 3))
+        image = np.asarray((0, 1, 2, 3), dtype=np.uint8)
+
+        with self.assertRaises(RuntimeError):
+            hg.connected_alternating_sequential_filter(graph, image, "bounding_box_width", [1, 2, 3])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR follows the direction discussed in #293 and is being built incrementally.

Its goal is to introduce support for dynamic component-tree algorithms in Higra while keeping the low-level machinery internal until the design stabilizes.

The first commit adds an internal mutable component-tree backend under `higra/detail/hierarchy`, with unit tests covering structural invariants, mutations, traversals, and iterator invalidation.

Further commits in this PR will build on top of this backend.
