### PR TITLE
Add `leaf_volume` parameter to `attribute_volume`

### DIFF
--- a/higra/attribute/tree_attributes.py
+++ b/higra/attribute/tree_attributes.py
@@ -46,10 +46,14 @@ def attribute_volume(tree, altitudes, area=None, leaf_volume=None):
 
         V(n) = area(n) * | altitude(n) - altitude(parent(n)) | +  \sum_{c \in children(n)} V(c)
 
+    The leaves are initialized with ``leaf_volume``. If ``leaf_volume`` is ``None``,
+    leaf volumes are set to 0.
+
     :param tree: input tree
     :param altitudes: node altitudes of the input tree
     :param area: area of the nodes of the input hierarchy (provided by :func:`~higra.attribute_area` on `tree`)
-    :param leaf_volume: initial volume of the leaves of the tree (default is 0 for all leaves)
+    :param leaf_volume: initial volume of the leaves of the tree (default is 0 for all leaves);
+        useful when leaves represent pre-existing regions, for example in region adjacency graph based hierarchies
     :return: a 1d array
     """
     if area is None:

--- a/higra/attribute/tree_attributes.py
+++ b/higra/attribute/tree_attributes.py
@@ -37,7 +37,7 @@ def attribute_area(tree, vertex_area=None, leaf_graph=None):
 
 
 @hg.auto_cache
-def attribute_volume(tree, altitudes, area=None):
+def attribute_volume(tree, altitudes, area=None, leaf_volume=None):
     """
     Volume of each node the given tree.
     The volume :math:`V(n)` of a node :math:`n` is defined recursively as:
@@ -49,6 +49,7 @@ def attribute_volume(tree, altitudes, area=None):
     :param tree: input tree
     :param altitudes: node altitudes of the input tree
     :param area: area of the nodes of the input hierarchy (provided by :func:`~higra.attribute_area` on `tree`)
+    :param leaf_volume: initial volume of the leaves of the tree (default is 0 for all leaves)
     :return: a 1d array
     """
     if area is None:
@@ -56,8 +57,11 @@ def attribute_volume(tree, altitudes, area=None):
 
     height = np.abs(altitudes[tree.parents()] - altitudes)
     height = height * area
-    volume_leaves = np.zeros(tree.num_leaves(), dtype=np.float64)
-    return hg.accumulate_and_add_sequential(tree, height, volume_leaves, hg.Accumulators.sum)
+
+    if leaf_volume is None:
+        leaf_volume = np.zeros(tree.num_leaves(), dtype=np.float64)
+
+    return hg.accumulate_and_add_sequential(tree, height, leaf_volume, hg.Accumulators.sum)
 
 
 @hg.argument_helper(hg.CptHierarchy)

--- a/test/python/test_attribute/test_attributes.py
+++ b/test/python/test_attribute/test_attributes.py
@@ -120,6 +120,25 @@ class TestAttributes(unittest.TestCase):
 
         self.assertTrue(np.allclose(ref_attribute, attribute))
 
+    def test_attribute_volume_with_rag_leaf_volume(self):
+        base_graph = hg.get_4_adjacency_graph((2, 2))
+        vertex_labels = np.asarray((0, 0, 1, 1))
+        rag = hg.make_region_adjacency_graph_from_labelisation(base_graph, vertex_labels)
+
+        tree = hg.Tree((2, 2, 3, 3))
+        altitudes = np.asarray((2, 2, 5, 5.))
+
+        base_vertex_area = np.ones(base_graph.num_vertices(), dtype=np.int64)
+        rag_vertex_area = hg.rag_accumulate_on_vertices(rag, hg.Accumulators.sum, base_vertex_area)
+        area = hg.attribute_area(tree, vertex_area=rag_vertex_area, leaf_graph=rag)
+
+        leaf_volume = np.asarray((3, 4.))
+
+        ref_attribute = [3, 4, 7, 7]
+        attribute = hg.attribute_volume(tree, altitudes, area=area, leaf_volume=leaf_volume)
+
+        self.assertEqual(len(leaf_volume), tree.num_leaves())
+        self.assertTrue(np.allclose(ref_attribute, attribute))
 
     def test_lca_map(self):
         tree, altitudes = TestAttributes.get_test_tree()

--- a/test/python/test_attribute/test_attributes.py
+++ b/test/python/test_attribute/test_attributes.py
@@ -109,6 +109,18 @@ class TestAttributes(unittest.TestCase):
 
         self.assertTrue(np.allclose(ref_attribute, attribute))
 
+    def test_attribute_volume_with_leaf_volume(self):
+        tree = hg.Tree((5, 5, 6, 6, 6, 7, 7, 7))
+        altitudes = np.asarray((0, 0, 0, 0, 0, 2, 1, 4.))
+        area = np.asarray((2, 1, 1, 3, 2, 3, 6, 9))
+        leaf_volume = np.asarray((1, 2, 3, 4, 5.))
+
+        ref_attribute = [1, 2, 3, 4, 5, 9, 30, 39]
+        attribute = hg.attribute_volume(tree, altitudes, area=area, leaf_volume=leaf_volume)
+
+        self.assertTrue(np.allclose(ref_attribute, attribute))
+
+
     def test_lca_map(self):
         tree, altitudes = TestAttributes.get_test_tree()
 


### PR DESCRIPTION
### Summary

This PR adds an optional `leaf_volume` parameter to `hg.attribute_volume`.

This makes it possible to initialize leaf volumes with non-zero values, which is useful when leaves represent pre-existing regions, for example in hierarchies built on region adjacency graphs.

### Changes

- added `leaf_volume=None` to `hg.attribute_volume`
- preserved the previous behavior when `leaf_volume` is not provided
- updated the docstring
- added tests for explicit leaf initialization and for a RAG-based example

### Notes

This is backward compatible: if `leaf_volume` is `None`, leaves are still initialized to zero as before.

Closes #184